### PR TITLE
Fix startup hang

### DIFF
--- a/include/SDK/PalSignatures.h
+++ b/include/SDK/PalSignatures.h
@@ -20,7 +20,6 @@ namespace Palworld {
             { "FPakPlatformFile::GetPakFolders", "48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 4C 89 74 24 20 55 48 8B EC 48 83 EC 40 48 8D 4D F0 48 8B DA E8" },
             { "AsyncTask", "48 8B C4 41 54 41 57 48 81 EC B8 00 00 00 48 89 58 08" },
             { "AGameModeBase::InitGameState", "40 53 48 83 EC 20 48 8B 41 10 48 8B D9 48 8B 91 F0 02 00 00" },
-            { "UPalDynamicItemWorldSubsystem::Create_ServerInternal", "40 55 53 56 41 54 41 55 41 56 48 8D AC 24 E8 FE FF FF" },
         };
         static inline std::unordered_map<std::string, std::string> SignaturesCallResolve {
         };

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -27,21 +27,6 @@ public:
         Palworld::SignatureManager::Initialize();
         MainLoader.PreInitialize();
 
-        register_tab(STR("Pal Schema"), [](CppUserModBase* instance) {
-            auto mod = dynamic_cast<PalSchema*>(instance);
-            if (!mod)
-            {
-                return;
-            }
-
-            if (ImGui::Button("Reload Schema Mods"))
-            {
-                UECustom::AsyncTask(UECustom::ENamedThreads::GameThread, [mod]() {
-                    mod->reload_mods();
-                });
-            }
-        });
-
         PS::Log<RC::LogLevel::Verbose>(STR("{} v{} by {} loaded.\n"), ModName, ModVersion, ModAuthors);
     }
 
@@ -56,7 +41,25 @@ public:
 
     auto on_ui_init() -> void override
     {
-        UE4SS_ENABLE_IMGUI()
+        if (UE4SSProgram::settings_manager.Debug.DebugConsoleVisible)
+        {
+            UE4SS_ENABLE_IMGUI()
+
+            register_tab(STR("Pal Schema"), [](CppUserModBase* instance) {
+                auto mod = dynamic_cast<PalSchema*>(instance);
+                if (!mod)
+                {
+                    return;
+                }
+
+                if (ImGui::Button("Reload Schema Mods"))
+                {
+                    UECustom::AsyncTask(UECustom::ENamedThreads::GameThread, [mod]() {
+                        mod->reload_mods();
+                    });
+                }
+            });
+        }
     }
 
     auto on_update() -> void override

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -19,7 +19,7 @@ public:
     PalSchema() : CppUserModBase()
     {
         ModName = STR("PalSchema");
-        ModVersion = STR("0.3.0");
+        ModVersion = STR("0.3.1");
         ModDescription = STR("Allows modifying of Palworld's DataTables and DataAssets dynamically.");
         ModAuthors = STR("Okaetsu");
 


### PR DESCRIPTION
Fixes a startup hang when GuiConsoleVisible is set to false in UE4SS-settings.ini and there's also a minor change to remove an unused UPalDynamicItemWorldSubsystem::Create_ServerInternal signature since the error generated by it might cause confusion.