### PR TITLE
Raw table fixes

### DIFF
--- a/include/SDK/PalSignatures.h
+++ b/include/SDK/PalSignatures.h
@@ -40,8 +40,6 @@ namespace Palworld {
             { "GetObjectsOfClass", "E8 ?? ?? ?? ?? 45 33 C0 48 89 6C 24 30 33 C9 41 8D 50 30 E8" },
             // FMemory::Free for GMalloc
             { "FMemory::Free", "E8 ?? ?? ?? ?? 4C 8D 45 D7 48 8D 55 27 48 8D 4D 17 E8" },
-            // Very important, unlikely to change ever.
-            { "FEngineLoop::Init", "E8 ?? ?? ?? ?? 48 8D 8C 24 B0 00 00 00 8B F0" },
         };
     };
 }

--- a/src/Loader/PalRawTableLoader.cpp
+++ b/src/Loader/PalRawTableLoader.cpp
@@ -52,8 +52,6 @@ namespace Palworld {
             PS::Log<LogLevel::Normal>(STR("{}: {} rows updated, {} rows added, {} rows deleted, {} error{}.\n"),
                 TableName, Result.SuccessfulModifications, Result.SuccessfulAdditions,
                 Result.SuccessfulDeletions, Result.ErrorCount, Result.ErrorCount > 1 || Result.ErrorCount == 0 ? STR("s") : STR(""));
-
-            m_tableDataMap.erase(TableName);
         }
     }
 

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
  
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               4
-#define VERSION_REVISION            2
+#define VERSION_REVISION            3
 #define VERSION_BUILD               0
  
 #define VER_FILE_DESCRIPTION_STR    "PalSchema"


### PR DESCRIPTION
Some tables get loaded and then unloaded by the game sometimes and the raw table loader only applies changes once which means when the table unloads, those changes are lost. This change makes it so that the changes get applied everytime the table gets loaded by the game again.