### PR TITLE
Update 0.5.0

### DIFF
--- a/include/Loader/PalItemModLoader.h
+++ b/include/Loader/PalItemModLoader.h
@@ -8,6 +8,8 @@ namespace UECustom {
 }
 
 namespace Palworld {
+    class UPalStaticItemDataTable;
+
 	class PalItemModLoader : public PalModLoaderBase {
 	public:
 		PalItemModLoader();
@@ -17,6 +19,8 @@ namespace Palworld {
 		void Initialize();
 
 		virtual void Load(const nlohmann::json& Data) override final;
+    public:
+        static UPalStaticItemDataBase* AddDummyItem(UPalStaticItemDataTable* StaticItemDataTable, const RC::Unreal::FName& ItemId);
 	private:
 		void Add(const RC::Unreal::FName& ItemId, const nlohmann::json& Data);
 
@@ -29,6 +33,8 @@ namespace Palworld {
 		void AddTranslations(const RC::Unreal::FName& ItemId, const nlohmann::json& Data);
 
 		void EditTranslations(const RC::Unreal::FName& ItemId, const nlohmann::json& Data);
+
+        void InitializeDummyTranslations();
 
 		UPalStaticItemDataAsset* m_itemDataAsset{};
 		UECustom::UDataTable* m_itemRecipeTable{};

--- a/include/Loader/PalMainLoader.h
+++ b/include/Loader/PalMainLoader.h
@@ -24,6 +24,8 @@ namespace UECustom {
 }
 
 namespace Palworld {
+    class UPalStaticItemDataTable;
+
 	class PalMainLoader {
 	public:
         PalMainLoader();
@@ -99,6 +101,8 @@ namespace Palworld {
 
         static void OnGameInstanceInit(RC::Unreal::UObject* This);
 
+        static RC::Unreal::UObject* StaticItemDataTable_Get(UPalStaticItemDataTable* This, RC::Unreal::FName ItemId);
+
         bool m_hasInit = false;
 
         static inline std::vector<std::function<void(UECustom::UDataTable*)>> DatatableSerializeCallbacks;
@@ -110,5 +114,6 @@ namespace Palworld {
         static inline SafetyHookInline GameInstanceInit_Hook;
         static inline SafetyHookInline PostLoad_Hook;
         static inline SafetyHookInline GetPakFolders_Hook;
+        static inline SafetyHookInline StaticItemDataTable_Get_Hook;
 	};
 }

--- a/include/Loader/PalMainLoader.h
+++ b/include/Loader/PalMainLoader.h
@@ -20,6 +20,7 @@ namespace RC::Unreal {
 
 namespace UECustom {
     class UDataTable;
+    class UCompositeDataTable;
 }
 
 namespace Palworld {
@@ -90,23 +91,23 @@ namespace Palworld {
 
         void ParseJsonFilesInPath(const std::filesystem::path& path, const std::function<void(const nlohmann::json&)>& callback);
     private:
-        static void HandleDataTableChanged(UECustom::UDataTable* This, RC::Unreal::FName param_1);
-
         static void PostLoad(RC::Unreal::UClass* This);
-
-        static void InitGameState(RC::Unreal::AGameModeBase* This);
 
         static void GetPakFolders(const RC::Unreal::TCHAR* CmdLine, RC::Unreal::TArray<RC::Unreal::FString>* OutPakFolders);
 
+        static void OnDataTableSerialized(UECustom::UDataTable* This, RC::Unreal::FArchive* Archive);
+
+        static void OnGameInstanceInit(RC::Unreal::UObject* This);
+
         bool m_hasInit = false;
 
-        static inline std::vector<std::function<void(UECustom::UDataTable*)>> HandleDataTableChangedCallbacks;
-        static inline std::vector<std::function<void(RC::Unreal::AGameModeBase*)>> InitGameStateCallbacks;
+        static inline std::vector<std::function<void(UECustom::UDataTable*)>> DatatableSerializeCallbacks;
+        static inline std::vector<std::function<void(RC::Unreal::UObject*)>> GameInstanceInitCallbacks;
         static inline std::vector<std::function<void(RC::Unreal::UClass*)>> PostLoadCallbacks;
         static inline std::vector<std::function<void()>> GetPakFoldersCallback;
 
-        static inline SafetyHookInline HandleDataTableChanged_Hook;
-        static inline SafetyHookInline InitGameState_Hook;
+        static inline SafetyHookInline DatatableSerialize_Hook;
+        static inline SafetyHookInline GameInstanceInit_Hook;
         static inline SafetyHookInline PostLoad_Hook;
         static inline SafetyHookInline GetPakFolders_Hook;
 	};

--- a/include/Loader/PalRawTableLoader.h
+++ b/include/Loader/PalRawTableLoader.h
@@ -47,6 +47,8 @@ namespace Palworld {
 
         void DeleteRow(UECustom::UDataTable* Table, const RC::Unreal::FName& RowName, LoadResult& OutResult);
 
+        void ModifyRowProperties(UECustom::UDataTable* Table, const RC::Unreal::FName& RowName, void* RowPtr, const nlohmann::json& Data, LoadResult& OutResult);
+
         void AddToTableDataMap(const std::string& TableName, const nlohmann::json& Data);
 	};
 }

--- a/include/SDK/PalSignatures.h
+++ b/include/SDK/PalSignatures.h
@@ -41,6 +41,7 @@ namespace Palworld {
             { "FMemory::Free", "E8 ?? ?? ?? ?? 4C 8D 45 D7 48 8D 55 27 48 8D 4D 17 E8" },
             // Raw Tables
             { "UDataTable::Serialize", "E8 ?? ?? ?? ?? 41 F6 06 01 0F 84 1D 03 00 00 48 89 5C 24 50" },
+            { "UPalStaticItemDataTable::Get", "E8 ?? ?? ?? ?? 48 85 C0 74 0B 8B 40" },
         };
     };
 }

--- a/include/SDK/PalSignatures.h
+++ b/include/SDK/PalSignatures.h
@@ -18,7 +18,6 @@ namespace Palworld {
             // Blueprint Loader apply logic
             { "UBlueprintGeneratedClass::PostLoadDefaultObject", "48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 30 48 8D 99 58 03 00 00" },
             // Raw Table apply logic
-            { "UDataTable::HandleDataTableChanged", "48 89 54 24 10 55 53 56 48 8D 6C 24 B9" },
             { "FPakPlatformFile::GetPakFolders", "48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 4C 89 74 24 20 55 48 8B EC 48 83 EC 40 48 8D 4D F0 48 8B DA E8" },
             // Important so we can easily run things on the Game Thread
             { "AsyncTask", "48 8B C4 41 54 41 57 48 81 EC B8 00 00 00 48 89 58 08" },
@@ -40,6 +39,8 @@ namespace Palworld {
             { "GetObjectsOfClass", "E8 ?? ?? ?? ?? 45 33 C0 48 89 6C 24 30 33 C9 41 8D 50 30 E8" },
             // FMemory::Free for GMalloc
             { "FMemory::Free", "E8 ?? ?? ?? ?? 4C 8D 45 D7 48 8D 55 27 48 8D 4D 17 E8" },
+            // Raw Tables
+            { "UDataTable::Serialize", "E8 ?? ?? ?? ?? 41 F6 06 01 0F 84 1D 03 00 00 48 89 5C 24 50" },
         };
     };
 }

--- a/include/SDK/Structs/Custom/FManagedStruct.h
+++ b/include/SDK/Structs/Custom/FManagedStruct.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace RC::Unreal {
+    class UScriptStruct;
+}
+
+namespace Palworld {
+    // A wrapper for UScriptStruct that automatically allocates and deallocates memory for the struct data in constructor/destructor.
+    // Should only be passed to functions that make a copy of the internal data, like UDataTable::AddRow.
+    class FManagedStruct {
+    public:
+        FManagedStruct(RC::Unreal::UScriptStruct* Struct);
+
+        ~FManagedStruct();
+
+        void* GetData();
+    private:
+        void* m_data;
+        RC::Unreal::UScriptStruct* m_struct;
+    };
+}

--- a/src/Loader/PalBlueprintModLoader.cpp
+++ b/src/Loader/PalBlueprintModLoader.cpp
@@ -239,7 +239,7 @@ namespace Palworld {
         for (auto& [InnerKey, InnerValue] : ComponentData.items())
         {
             auto ComponentPropertyName = RC::to_generic_string(InnerKey);
-            auto ComponentProperty = Component->GetPropertyByNameInChain(ComponentPropertyName.c_str());
+            auto ComponentProperty = PropertyHelper::GetPropertyByName(Component->GetClassPrivate(), ComponentPropertyName.c_str());
             if (!ComponentProperty)
             {
                 PS::Log<LogLevel::Warning>(STR("Property {} doesn't exist in {}\n"), ComponentPropertyName, Component->GetName());

--- a/src/SDK/Classes/PalStaticItemDataTable.cpp
+++ b/src/SDK/Classes/PalStaticItemDataTable.cpp
@@ -1,14 +1,13 @@
 #include "SDK/Classes/PalStaticItemDataTable.h"
 #include "SDK/Classes/PalStaticItemDataAsset.h"
+#include "Helpers/Casting.hpp"
+
+using namespace RC;
 
 namespace Palworld {
     UPalStaticItemDataAsset* UPalStaticItemDataTable::GetDataAsset()
     {
-        auto DataAsset = this->GetValuePtrByPropertyNameInChain<UPalStaticItemDataAsset*>(STR("DataAsset"));
-        if (DataAsset)
-        {
-            return *DataAsset;
-        }
-        return nullptr;
+        auto DataAsset = *Helper::Casting::ptr_cast<UPalStaticItemDataAsset**>(this, 0x28);
+        return DataAsset;
     }
 }

--- a/src/SDK/Helper/PropertyHelper.cpp
+++ b/src/SDK/Helper/PropertyHelper.cpp
@@ -526,9 +526,10 @@ namespace Palworld {
     RC::Unreal::FProperty* PropertyHelper::GetPropertyByName(RC::Unreal::UScriptStruct* Struct, const RC::StringType& PropertyName)
     {
         FProperty* Property = nullptr;
+        FName PropertyFName = FName(PropertyName, FNAME_Add);
         for (FProperty* It = Struct->GetPropertyLink(); It != nullptr; It = It->GetPropertyLinkNext())
         {
-            if (It->GetName() == PropertyName)
+            if (It->GetFName() == PropertyFName)
             {
                 Property = It;
             }

--- a/src/SDK/Structs/Custom/FManagedStruct.cpp
+++ b/src/SDK/Structs/Custom/FManagedStruct.cpp
@@ -1,0 +1,27 @@
+#include "SDK/Structs/Custom/FManagedStruct.h"
+#include "Unreal/Core/HAL/UnrealMemory.hpp"
+#include "Unreal/UScriptStruct.hpp"
+#include "DynamicOutput/DynamicOutput.hpp"
+
+using namespace RC;
+using namespace RC::Unreal;
+
+namespace Palworld {
+    FManagedStruct::FManagedStruct(UScriptStruct* Struct)
+    {
+        m_struct = Struct;
+        m_data = FMemory::Malloc(Struct->GetStructureSize());
+        Struct->InitializeStruct(m_data);
+    }
+
+    FManagedStruct::~FManagedStruct()
+    {
+        m_struct->DestroyStruct(m_data);
+        FMemory::Free(m_data);
+    }
+
+    void* FManagedStruct::GetData()
+    {
+        return m_data;
+    }
+}

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -16,7 +16,7 @@ public:
     PalSchema() : CppUserModBase()
     {
         ModName = STR("PalSchema");
-        ModVersion = STR("0.4.3");
+        ModVersion = STR("0.5.0");
         ModDescription = STR("Allows modifying of Palworld's assets dynamically.");
         ModAuthors = STR("Okaetsu");
 

--- a/version.h
+++ b/version.h
@@ -2,8 +2,8 @@
 #define STRINGIZE(s) STRINGIZE2(s)
  
 #define VERSION_MAJOR               0
-#define VERSION_MINOR               4
-#define VERSION_REVISION            3
+#define VERSION_MINOR               5
+#define VERSION_REVISION            0
 #define VERSION_BUILD               0
  
 #define VER_FILE_DESCRIPTION_STR    "PalSchema"


### PR DESCRIPTION
- Improve reliability of raw table and blueprint mod loading, same for other tables like items, pals, etc.
- Add dummy item to replace modded items when the mod adding those items is removed to prevent crashing on world load.
- Fix memory leak with raw tables. When new data is added to raw tables, Unreal makes a copy of that data, which means the original passed data would still stay in memory, this change makes it so that the original data gets cleared after the AddRow either fails or succeeds.