### PR TITLE
Fix blueprint loader not functioning with components

### DIFF
--- a/include/SDK/Classes/Custom/UInheritableComponentHandler.h
+++ b/include/SDK/Classes/Custom/UInheritableComponentHandler.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Unreal/UObject.hpp"
+#include "SDK/Classes/Custom/UObjectWrapper.h"
 #include "Unreal/UnrealCoreStructs.hpp"
 
 namespace UECustom {
@@ -24,7 +24,7 @@ namespace UECustom {
         RC::Unreal::uint8 CookedComponentInstancingData[0x48];
     };
 
-    class UInheritableComponentHandler : public RC::Unreal::UObject {
+    class UInheritableComponentHandler : public UECustom::UObjectWrapper {
     public:
         RC::Unreal::TArray<FComponentOverrideRecord> GetRecords();
     };

--- a/include/SDK/Classes/Custom/UObjectWrapper.h
+++ b/include/SDK/Classes/Custom/UObjectWrapper.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Unreal/UObject.hpp"
+
+namespace UECustom {
+    // Wrapper class for UObject which is overriding certain functions to use functions from PropertyHelper due to requiring the use of them early.
+    // This avoids the need for custom UE4SS build since UE4SS' UE API doesn't initialize early enough yet.
+    // Calling GetValuePtrByPropertyNameInChain from UE4SS' own API for example would just return an empty object or null when PalSchema needs to call it.
+    class UObjectWrapper : public RC::Unreal::UObject {
+    public:
+        void* GetValuePtrByPropertyNameInChain(const RC::Unreal::TCHAR* PropertyName);
+
+        template<RC::Unreal::UObjectPointerDerivativeOrAnyNonUObject ReturnType>
+        ReturnType* GetValuePtrByPropertyNameInChain(const TCHAR* PropertyName)
+        {
+            return static_cast<ReturnType*>(UObjectWrapper::GetValuePtrByPropertyNameInChain(PropertyName));
+        }
+    };
+}

--- a/include/SDK/Classes/Custom/USCS_Node.h
+++ b/include/SDK/Classes/Custom/USCS_Node.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Unreal/UObject.hpp"
+#include "SDK/Classes/Custom/UObjectWrapper.h"
 
 namespace UECustom {
-    class USCS_Node : public RC::Unreal::UObject {
+    class USCS_Node : public UECustom::UObjectWrapper {
     public:
         RC::Unreal::UObject* GetComponentTemplate();
     };

--- a/include/SDK/Classes/Custom/USimpleConstructionScript.h
+++ b/include/SDK/Classes/Custom/USimpleConstructionScript.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "Unreal/UObject.hpp"
+#include "SDK/Classes/Custom/UObjectWrapper.h"
 #include "Core/Containers/Array.hpp"
 #include "SDK/Classes/Custom/USCS_Node.h"
 
 namespace UECustom {
-    class USimpleConstructionScript : public RC::Unreal::UObject {
+    class USimpleConstructionScript : public UECustom::UObjectWrapper {
     public:
         RC::Unreal::TArray<USCS_Node*>& GetAllNodes();
     };

--- a/include/SDK/Helper/PropertyHelper.h
+++ b/include/SDK/Helper/PropertyHelper.h
@@ -81,6 +81,15 @@ namespace Palworld::PropertyHelper {
         return CastProperty<FFieldDerivedType>(Property);
     }
 
+    void* GetValuePtrByPropertyNameInChain(RC::Unreal::UObject* Instance, const RC::StringType& PropertyName);
+
+    template<typename ReturnType>
+    ReturnType* GetValuePtrByPropertyNameInChain(RC::Unreal::UObject* Instance, const RC::StringType& PropertyName)
+    {
+        auto ValuePtr = PropertyHelper::GetValuePtrByPropertyNameInChain(Instance, PropertyName);
+        return static_cast<ReturnType*>(ValuePtr);
+    }
+
     RC::Unreal::FFieldClass* FindFieldClassByName(const RC::Unreal::FName& Name);
 
     RC::Unreal::FFieldClass* FindFieldClassByName(const RC::StringType& Name);

--- a/src/SDK/Classes/Custom/UBlueprintGeneratedClass.cpp
+++ b/src/SDK/Classes/Custom/UBlueprintGeneratedClass.cpp
@@ -1,11 +1,16 @@
 #include "SDK/Classes/Custom/UBlueprintGeneratedClass.h"
 #include "SDK/Classes/Custom/UInheritableComponentHandler.h"
+#include "Unreal/CoreUObject/UObject/UnrealType.hpp"
+#include "SDK/Classes/Custom/UObjectWrapper.h"
+#include "SDK/Helper/PropertyHelper.h"
+
+using namespace Palworld;
 
 namespace UECustom {
     UInheritableComponentHandler* UBlueprintGeneratedClass::GetInheritableComponentHandler()
     {
         auto InheritableComponentHandler = 
-            this->GetValuePtrByPropertyNameInChain<RC::Unreal::TObjectPtr<UInheritableComponentHandler>>(STR("InheritableComponentHandler"));
+            PropertyHelper::GetValuePtrByPropertyNameInChain<RC::Unreal::TObjectPtr<UInheritableComponentHandler>>(this, (STR("InheritableComponentHandler")));
 
         if (!InheritableComponentHandler)
         {
@@ -18,7 +23,7 @@ namespace UECustom {
     USimpleConstructionScript* UBlueprintGeneratedClass::GetSimpleConstructionScript()
     {
         auto SimpleConstructionScript =
-            this->GetValuePtrByPropertyNameInChain<RC::Unreal::TObjectPtr<USimpleConstructionScript>>(STR("SimpleConstructionScript"));
+            PropertyHelper::GetValuePtrByPropertyNameInChain<RC::Unreal::TObjectPtr<USimpleConstructionScript>>(this, (STR("SimpleConstructionScript")));
 
         if (!SimpleConstructionScript)
         {

--- a/src/SDK/Classes/Custom/UInheritableComponentHandler.cpp
+++ b/src/SDK/Classes/Custom/UInheritableComponentHandler.cpp
@@ -6,6 +6,13 @@ using namespace RC::Unreal;
 namespace UECustom {
     TArray<FComponentOverrideRecord> UECustom::UInheritableComponentHandler::GetRecords()
     {
-        return *this->GetValuePtrByPropertyNameInChain<TArray<FComponentOverrideRecord>>(STR("Records"));
+        auto Records = this->GetValuePtrByPropertyNameInChain<TArray<FComponentOverrideRecord>>(STR("Records"));
+        
+        if (!Records)
+        {
+            return {};
+        }
+
+        return *Records;
     }
 }

--- a/src/SDK/Classes/Custom/UObjectWrapper.cpp
+++ b/src/SDK/Classes/Custom/UObjectWrapper.cpp
@@ -1,0 +1,12 @@
+#include "SDK/Classes/Custom/UObjectWrapper.h"
+#include "SDK/Helper/PropertyHelper.h"
+
+using namespace RC;
+using namespace RC::Unreal;
+
+namespace UECustom {
+    void* UObjectWrapper::GetValuePtrByPropertyNameInChain(const TCHAR* PropertyName)
+    {
+        return Palworld::PropertyHelper::GetValuePtrByPropertyNameInChain(this, PropertyName);
+    }
+}

--- a/src/SDK/Helper/PropertyHelper.cpp
+++ b/src/SDK/Helper/PropertyHelper.cpp
@@ -1,31 +1,19 @@
 #include "Unreal/FProperty.hpp"
-#include "Unreal/Property/FArrayProperty.hpp"
-#include "Unreal/Property/FBoolProperty.hpp"
-#include "Unreal/Property/FNameProperty.hpp"
-#include "Unreal/Property/FNumericProperty.hpp"
 #include "Unreal/Property/FEnumProperty.hpp"
-#include "Unreal/Property/FMapProperty.hpp"
-#include "Unreal/Property/FStructProperty.hpp"
 #include "Unreal/Property/FStrProperty.hpp"
-#include "Unreal/Property/FClassProperty.hpp"
-#include "Unreal/Property/FSoftClassProperty.hpp"
-#include "Unreal/Property/FSoftObjectProperty.hpp"
 #include "Unreal/Property/FTextProperty.hpp"
-#include "Unreal/FString.hpp"
-#include "Unreal/NameTypes.hpp"
+#include "Unreal/CoreUObject/UObject/UnrealType.hpp"
 #include "Unreal/CoreUObject/UObject/Class.hpp"
-#include "Unreal/UEnum.hpp"
-#include "Unreal/UScriptStruct.hpp"
+#include "Helpers/Casting.hpp"
 #include "SDK/Classes/TSoftObjectPtr.h"
 #include "SDK/Classes/TSoftClassPtr.h"
 #include "SDK/Classes/KismetSystemLibrary.h"
 #include "SDK/Structs/Custom/FManagedValue.h"
 #include "SDK/Structs/Custom/FScriptMapHelper.h"
 #include "SDK/Structs/Custom/FScriptArrayHelper.h"
-#include "Utility/Logging.h"
 #include "SDK/Helper/PropertyHelper.h"
 #include "SDK/PalSignatures.h"
-#include "Helpers/Casting.hpp"
+#include "Utility/Logging.h"
 
 using namespace RC;
 using namespace RC::Unreal;
@@ -548,6 +536,23 @@ namespace Palworld {
             }
         }
         return Property;
+    }
+
+    void* PropertyHelper::GetValuePtrByPropertyNameInChain(RC::Unreal::UObject* Instance, const RC::StringType& PropertyName)
+    {
+        if (!Instance)
+        {
+            return nullptr;
+        }
+
+        RC::Unreal::FProperty* Property = PropertyHelper::GetPropertyByName(Instance->GetClassPrivate(), PropertyName);
+        if (!Property)
+        {
+            return nullptr;
+        }
+
+        auto ValuePtr = Property->ContainerPtrToValuePtr<void>(Instance);
+        return ValuePtr;
     }
 
     RC::Unreal::FFieldClass* PropertyHelper::FindFieldClassByName(const RC::Unreal::FName& Name)

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
  
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               5
-#define VERSION_REVISION            0
+#define VERSION_REVISION            1
 #define VERSION_BUILD               0
  
 #define VER_FILE_DESCRIPTION_STR    "PalSchema"


### PR DESCRIPTION
Should hopefully fix component related blueprint mod issues. This was happening, because UE4SS accessors were still being used rather than the ones implemented in PalSchema (PropertyHelper) which enable earlier access to UE internals.