### PR TITLE
Fix spawners not working in certain world cells

### DIFF
--- a/include/Loader/PalSpawnLoader.h
+++ b/include/Loader/PalSpawnLoader.h
@@ -46,6 +46,8 @@ namespace Palworld {
         RC::Unreal::TArray<UECustom::UWorldPartitionRuntimeLevelStreamingCell*> m_loadedCells;
         std::vector<PS::SpawnerInfo> m_spawns;
 
+        void SetupWorldPartitionHooks();
+
         void LoadSpawns(const RC::StringType& modName, const nlohmann::json& data);
 
         void RegisterSpawn(const std::filesystem::path::string_type& modName, const nlohmann::json& value);
@@ -65,6 +67,11 @@ namespace Palworld {
         void UnloadMod(const std::filesystem::path::string_type& modName);
 
         void CleanupSpawns();
+    private:
+        RC::Unreal::CallbackId m_onLevelShownCallbackId{};
+        RC::Unreal::CallbackId m_onLevelHiddenCallbackId{};
+        RC::Unreal::UFunction* m_onLevelShownFunction = nullptr;
+        RC::Unreal::UFunction* m_onLevelHiddenFunction = nullptr;
     private:
         static inline std::function<void(RC::Unreal::UWorld*, bool, bool, RC::Unreal::UWorld*)> WorldCleanupCallback = nullptr;
         static inline SafetyHookInline WorldCleanupHook;

--- a/src/Loader/PalSpawnLoader.cpp
+++ b/src/Loader/PalSpawnLoader.cpp
@@ -93,6 +93,7 @@ namespace Palworld {
 
             WorldCleanupHook = safetyhook::create_inline(reinterpret_cast<void*>(CleanupWorld_FuncPtr),
                 OnWorldCleanup);
+
             SetupWorldPartitionHooks();
         }
         catch (const std::exception& e)
@@ -118,12 +119,6 @@ namespace Palworld {
         if (cell->GetIsHLOD())
         {
             // Skip HLOD. From what I noticed, if a spawner is created inside a HLOD, it more than likely will not despawn ever which is not ideal.
-            return;
-        }
-
-        if (cell->GetLevel() == 0)
-        {
-            // Skip L0 grids, all the other spawners seem to be on L1 or above.
             return;
         }
 

--- a/src/Loader/PalSpawnLoader.cpp
+++ b/src/Loader/PalSpawnLoader.cpp
@@ -30,6 +30,8 @@ namespace Palworld {
     PalSpawnLoader::~PalSpawnLoader() {
         auto expected = WorldCleanupHook.disable();
         WorldCleanupHook = {};
+        m_onLevelShownFunction->UnregisterHook(m_onLevelShownCallbackId);
+        m_onLevelHiddenFunction->UnregisterHook(m_onLevelHiddenCallbackId);
     }
 
     void PalSpawnLoader::Reload(const std::filesystem::path::string_type& modName, const nlohmann::json& data)
@@ -91,6 +93,7 @@ namespace Palworld {
 
             WorldCleanupHook = safetyhook::create_inline(reinterpret_cast<void*>(CleanupWorld_FuncPtr),
                 OnWorldCleanup);
+            SetupWorldPartitionHooks();
         }
         catch (const std::exception& e)
         {
@@ -132,6 +135,21 @@ namespace Palworld {
     {
         DestroySpawnersInCell(cell);
         m_loadedCells.Remove(cell);
+    }
+
+    void PalSpawnLoader::SetupWorldPartitionHooks()
+    {
+        m_onLevelShownFunction = UECustom::UObjectGlobals::StaticFindObject<UFunction*>(nullptr, nullptr, STR("/Script/Engine.WorldPartitionRuntimeLevelStreamingCell:OnLevelShown"));
+        m_onLevelShownCallbackId = m_onLevelShownFunction->RegisterPostHook([&](UnrealScriptFunctionCallableContext& Context, void* CustomData) {
+            auto cell = static_cast<UECustom::UWorldPartitionRuntimeLevelStreamingCell*>(Context.Context);
+            OnCellLoaded(cell);
+        });
+
+        m_onLevelHiddenFunction = UECustom::UObjectGlobals::StaticFindObject<UFunction*>(nullptr, nullptr, STR("/Script/Engine.WorldPartitionRuntimeLevelStreamingCell:OnLevelHidden"));
+        m_onLevelHiddenCallbackId = m_onLevelHiddenFunction->RegisterPostHook([&](UnrealScriptFunctionCallableContext& Context, void* CustomData) {
+            auto cell = static_cast<UECustom::UWorldPartitionRuntimeLevelStreamingCell*>(Context.Context);
+            OnCellUnloaded(cell);
+        });
     }
 
     void PalSpawnLoader::LoadSpawns(const RC::StringType& modName, const nlohmann::json& data)


### PR DESCRIPTION
There was an issue with spawners not working in some locations due to L0 cells being excluded. This was a misunderstanding on my part, because there are existing spawners in L0 cells which I missed during my search at the time.

Fix for this is provided by @GungnirIncarnate which I reimplemented from his L0/HLOD branch.