### PR TITLE
Fix discrepancy between common and normal datatables

### DIFF
--- a/include/SDK/Classes/Custom/UDataTableStore.h
+++ b/include/SDK/Classes/Custom/UDataTableStore.h
@@ -24,8 +24,6 @@ namespace UECustom {
         void Add(const std::string& name, RC::Unreal::UDataTable* datatable);
 
         void Add(RC::Unreal::UDataTable* datatable);
-
-        void Initialize();
     private:
         std::mutex m_mutex;
         std::unordered_map<std::string, RC::Unreal::UDataTable*> m_datatableMap;

--- a/include/SDK/Classes/Custom/UDataTableStore.h
+++ b/include/SDK/Classes/Custom/UDataTableStore.h
@@ -29,6 +29,7 @@ namespace UECustom {
     private:
         std::mutex m_mutex;
         std::unordered_map<std::string, RC::Unreal::UDataTable*> m_datatableMap;
+        std::unordered_map<std::string, RC::Unreal::UDataTable*> m_parentTableNameToCompositeDatatableMap;
         std::unordered_map<DatatableSerializeCallbackId, DatatableSerializeCallback> m_callbackMap;
 
         static DatatableSerializeCallbackId GenerateDatatableSerializeCallbackId();

--- a/src/Loader/PalRawTableLoader.cpp
+++ b/src/Loader/PalRawTableLoader.cpp
@@ -44,6 +44,11 @@ namespace Palworld {
 
     void PalRawTableLoader::Apply(UECustom::UCompositeDataTable* compositeDatatable)
     {
+        /* TODO: Add better handling for composite datatables similar to what UDataTableRegistry::GetDatatableByName does.
+        *  This works for now since there is always only one _Common datatable counterpart, but isn't future proof due to potential naming changes, etc.
+        *  Also runs the risk of applying modifications twice when two parent tables have _Common at the end.
+        */
+
         auto parentTables = compositeDatatable->GetParentTables();
         for (auto& parentTable : parentTables)
         {

--- a/src/SDK/Classes/Custom/UDataTableStore.cpp
+++ b/src/SDK/Classes/Custom/UDataTableStore.cpp
@@ -1,3 +1,4 @@
+#include "SDK/Classes/UCompositeDataTable.h"
 #include "SDK/Classes/Custom/UDataTableStore.h"
 #include "SDK/Classes/Custom/UObjectGlobals.h"
 #include "Utility/Logging.h"
@@ -12,10 +13,16 @@ using namespace RC::Unreal;
 namespace UECustom {
     RC::Unreal::UDataTable* UDataTableRegistry::GetDatatableByName(const std::string& name)
     {
-        auto datatable = m_datatableMap.find(name);
-        if (datatable != m_datatableMap.end())
+        auto parentDatatableIt = m_parentTableNameToCompositeDatatableMap.find(name);
+        if (parentDatatableIt != m_parentTableNameToCompositeDatatableMap.end())
         {
-            return datatable->second;
+            return parentDatatableIt->second;
+        }
+
+        auto datatableIt = m_datatableMap.find(name);
+        if (datatableIt != m_datatableMap.end())
+        {
+            return datatableIt->second;
         }
 
         return nullptr;
@@ -39,6 +46,15 @@ namespace UECustom {
     void UDataTableRegistry::Add(const std::string& name, RC::Unreal::UDataTable* datatable)
     {
         m_datatableMap.insert_or_assign(name, datatable);
+
+        if (datatable->GetClassPrivate() == UECustom::UCompositeDataTable::StaticClass())
+        {
+            auto compositeDatatable = static_cast<UECustom::UCompositeDataTable*>(datatable);
+            for (auto& parentTable : compositeDatatable->GetParentTables())
+            {
+                m_parentTableNameToCompositeDatatableMap.emplace(RC::to_string(parentTable->GetName()), compositeDatatable);
+            }
+        }
 
         std::lock_guard<std::mutex> guard(m_mutex);
         for (auto& [callbackId, callback] : m_callbackMap)

--- a/src/SDK/Classes/Custom/UDataTableStore.cpp
+++ b/src/SDK/Classes/Custom/UDataTableStore.cpp
@@ -69,32 +69,6 @@ namespace UECustom {
         Add(RC::to_string(name), datatable);
     }
 
-    void UDataTableRegistry::Initialize()
-    {
-        TArray<UObject*> results;
-
-        auto datatableClass = RC::Unreal::UDataTable::StaticClass();
-        if (!datatableClass)
-        {
-            PS::Log<LogLevel::Error>(STR("Unable to initialize UDataTableRegistry, failed to get /Script/Engine.DataTable\n"));
-            return;
-        }
-
-        PS::Log<LogLevel::Verbose>(STR("UClass for UDataTable found, fetching UDataTables...\n"));
-        UECustom::UObjectGlobals::GetObjectsOfClass(datatableClass, results);
-
-        int addedDatatables = 0;
-        for (auto& object : results)
-        {
-            auto datatable = static_cast<RC::Unreal::UDataTable*>(object);
-            auto name = object->GetNamePrivate().ToString();
-            Add(RC::to_string(name), datatable);
-            addedDatatables++;
-        }
-
-        PS::Log<LogLevel::Verbose>(STR("Finished mapping {} UDataTables.\n"), addedDatatables);
-    }
-
     DatatableSerializeCallbackId UDataTableRegistry::GenerateDatatableSerializeCallbackId()
     {
         static RC::Unreal::uint64 datatableSerializeCallbackId = 0;


### PR DESCRIPTION
This PR should fix the age long issue with PalSchema and tables that have a normal and a _Common variant, e.g. `DT_PalMonsterParameter` and `DT_PalMonsterParameter_Common`.

Before you would have to explicitly target the normal variant, so in this case `DT_PalMonsterParameter` and if you were to target the _Common variant, no changes would occur. This change makes it so that when a common table is entered as the targeted table name, it will apply the changes to the normal variant.

In short: it doesn't matter anymore if you write `DT_PalMonsterParameter` or `DT_PalMonsterParameter_Common`, both will be redirected to `DT_PalMonsterParameter`.

I haven't observed any breaking changes from my testing so existing mods shouldn't be affected.