### PR TITLE
Add easier ranch suitability integration and asset reference support for FObjectProperty

### DIFF
--- a/assets/examples/CattivaRanchSuitability/blueprints/blueprint_pinkcat.jsonc
+++ b/assets/examples/CattivaRanchSuitability/blueprints/blueprint_pinkcat.jsonc
@@ -1,0 +1,43 @@
+{
+    "BP_PinkCat_C": {
+        "StaticCharacterParameterComponent": {
+            "SpawnItem": {
+                // Key (Rank) == Star levels of your pals
+                // Internally there is no concept of 0-star and ranks start from 1 which is equivalent to 0-star with 5 being equivalent to 4-star.
+                // Value corresponds to an entry in 'DT_ItemLotteryDataTable' by its 'FieldName'. See the lottery.jsonc file in raw folder.
+                "FieldLotteryNameByRank": [
+                  {
+                    "Key": 1,
+                    "Value": {
+                      "Key": "CharacterSpawnItem_PinkCat_1"
+                    }
+                  },
+                  {
+                    "Key": 2,
+                    "Value": {
+                      "Key": "CharacterSpawnItem_PinkCat_2"
+                    }
+                  },
+                  {
+                    "Key": 3,
+                    "Value": {
+                      "Key": "CharacterSpawnItem_PinkCat_3"
+                    }
+                  },
+                  {
+                    "Key": 4,
+                    "Value": {
+                      "Key": "CharacterSpawnItem_PinkCat_4"
+                    }
+                  },
+                  {
+                    "Key": 5,
+                    "Value": {
+                      "Key": "CharacterSpawnItem_PinkCat_5"
+                    }
+                  }
+                ]
+            }
+        }
+    }
+}

--- a/assets/examples/CattivaRanchSuitability/pals/pinkcat.jsonc
+++ b/assets/examples/CattivaRanchSuitability/pals/pinkcat.jsonc
@@ -1,0 +1,37 @@
+{
+    "PinkCat": {
+        // Values higher than 1 in WorkSuitability_MonsterFarm add no benefit.
+        "WorkSuitability_MonsterFarm": 1,
+        // Game itself does not care about RanchActionData, this is specifically only read by PalSchema to aid in creation of a custom SpawnItem action.
+        "RanchActionData": {
+            // Animation loop to play once the spawn action starts.
+            "ChargeMontage": "/Game/Pal/Animation/Character/Monster/PinkCat/AM_PinkCat_FarSkill_ActionLoop.AM_PinkCat_FarSkill_ActionLoop",
+
+            // Animation to play once the item is spawned. Make sure it's not a loop, otherwise the pal will get stuck forever.
+            "FunMontage": "/Game/Pal/Animation/Character/Monster/PinkCat/AM_PinkCat_Damage.AM_PinkCat_Damage",
+
+            // Facial expression to show during spawn action.
+            "ChargeFacialEye": "EPalFacialEyeType::Pain",
+
+            // Facial expression to show when the item is spawned.
+            "FunFacialEye": "EPalFacialEyeType::Smile",
+
+            // Name of the bone in a Pal's skeleton to spawn the item from. Leaving it as None is usually fine if you're unsure.
+            "SpawnSocketName": "None",
+
+            // The spawned item's relative location from the Pal's selected bone socket.
+            "SpawnLocationOffset": {
+                "X": 0.0,
+                "Y": 0.0,
+                "Z": 0.0
+            },
+
+            // Initial rotation of the spawned item.
+            "SpawnItemRotator": {
+              "Pitch": 0.0,
+              "Yaw": 0.0,
+              "Roll": 0.0
+            }
+        }
+    }
+}

--- a/assets/examples/CattivaRanchSuitability/raw/lottery.jsonc
+++ b/assets/examples/CattivaRanchSuitability/raw/lottery.jsonc
@@ -1,0 +1,73 @@
+{
+    "DT_ItemLotteryDataTable": {
+        // Row name doesn't matter, but make it something unique to avoid accidentally editing existing rows unless that's your goal.
+        "PinkCatRanch_001": {
+            // FieldName is important and will be referenced by the pal's blueprint.
+            "FieldName": "CharacterSpawnItem_PinkCat_1",
+
+            // SlotNo should always be 1, for ranch suitability no other slots work.
+            "SlotNo": 1,
+
+            // WeightInSlot is only relevant if you have other Lottery entries sharing the same slot.
+            // You can look up Vixy's Lottery entries in FModel for a random spawn example (DT_ItemLotteryDataTable): Ctrl+F -> "CharacterSpawnItem_CuteFoxRank1"
+            "WeightInSlot": 1.0,
+
+            // StaticItemId is the ID of the item we want to spawn which in this example corresponds to Gold.
+            // Refer to https://paldeck.cc/items for a list of items and their IDs.
+            "StaticItemId": "Money",
+
+            // MinNum is the minimum quantity to spawn.
+            "MinNum": 1,
+
+            // MaxNum is the maximum quantity to spawn.
+            "MaxNum": 1,
+
+            // Should generally be 1 except in the case of Money where MinNum, MaxNum and NumUnit must match or weird things will happen.
+            // Once again, see "CharacterSpawnItem_CuteFoxRank1" for a good example of how to use these three values correctly.
+            "NumUnit": 1,
+
+            // Always keep this as EPalMapObjectTreasureGradeType::Grade1 for ranch.
+            "TreasureBoxGrade": "EPalMapObjectTreasureGradeType::Grade1"
+        },
+        "PinkCatRanch_002": {
+            "FieldName": "CharacterSpawnItem_PinkCat_2",
+            "SlotNo": 1,
+            "WeightInSlot": 1.0,
+            "StaticItemId": "Money",
+            "MinNum": 5,
+            "MaxNum": 5,
+            "NumUnit": 5,
+            "TreasureBoxGrade": "EPalMapObjectTreasureGradeType::Grade1"
+        },
+        "PinkCatRanch_003": {
+            "FieldName": "CharacterSpawnItem_PinkCat_3",
+            "SlotNo": 1,
+            "WeightInSlot": 1.0,
+            "StaticItemId": "Money",
+            "MinNum": 10,
+            "MaxNum": 10,
+            "NumUnit": 10,
+            "TreasureBoxGrade": "EPalMapObjectTreasureGradeType::Grade1"
+        },
+        "PinkCatRanch_004": {
+            "FieldName": "CharacterSpawnItem_PinkCat_4",
+            "SlotNo": 1,
+            "WeightInSlot": 1.0,
+            "StaticItemId": "Money",
+            "MinNum": 15,
+            "MaxNum": 15,
+            "NumUnit": 15,
+            "TreasureBoxGrade": "EPalMapObjectTreasureGradeType::Grade1"
+        },
+        "PinkCatRanch_005": {
+            "FieldName": "CharacterSpawnItem_PinkCat_5",
+            "SlotNo": 1,
+            "WeightInSlot": 1.0,
+            "StaticItemId": "Money",
+            "MinNum": 20,
+            "MaxNum": 20,
+            "NumUnit": 20,
+            "TreasureBoxGrade": "EPalMapObjectTreasureGradeType::Grade1"
+        }
+    }
+}

--- a/assets/examples/CattivaRanchSuitability/raw/lottery_probability.jsonc
+++ b/assets/examples/CattivaRanchSuitability/raw/lottery_probability.jsonc
@@ -1,0 +1,23 @@
+{
+    // When you add a new "FieldName" in DT_ItemLotteryDataTable, always remember to create a corresponding entry in DT_FieldLotteryNameDataTable.
+    // Your custom entries will not work otherwise!!
+    "DT_FieldLotteryNameDataTable": {
+        // Row name should correspond to a "FieldName" in DT_ItemLotteryDataTable.
+        "CharacterSpawnItem_PinkCat_1": {
+            // Percent chance of the pal actually creating a drop at the ranch. 0% - 100%
+            "ItemSlot1_ProbabilityPercent": 100.0
+        },
+        "CharacterSpawnItem_PinkCat_2": {
+            "ItemSlot1_ProbabilityPercent": 100.0
+        },
+        "CharacterSpawnItem_PinkCat_3": {
+            "ItemSlot1_ProbabilityPercent": 100.0
+        },
+        "CharacterSpawnItem_PinkCat_4": {
+            "ItemSlot1_ProbabilityPercent": 100.0
+        },
+        "CharacterSpawnItem_PinkCat_5": {
+            "ItemSlot1_ProbabilityPercent": 100.0
+        }
+    }
+}

--- a/include/Loader/PalMonsterModLoader.h
+++ b/include/Loader/PalMonsterModLoader.h
@@ -21,11 +21,18 @@ namespace Palworld {
         virtual bool CanInitialize(const EEngineLifecyclePhase& engineLifecyclePhase) override final;
         virtual bool OnInitialize() override final;
     private:
+        // Creates a new BP_Action_SpawnItem class and returns the class default object for it.
+        RC::Unreal::UObject* CreateSpawnItemActionByCharacterId(const RC::Unreal::FName& characterId);
+
+        void InitializeDefaultRanchPalsList();
+
         void LoadPals(const nlohmann::json& data);
 
         void Add(const RC::Unreal::FName& CharacterId, const nlohmann::json& properties);
 
         void Edit(uint8_t* TableRow, const RC::Unreal::FName& CharacterId, const nlohmann::json& properties);
+
+        void HandleRanchSuitability(uint8_t* row, const RC::Unreal::FName& characterId, const nlohmann::json& data);
 
         void AddIcon(const RC::Unreal::FName& CharacterId, const RC::StringType& IconPath);
 
@@ -39,13 +46,16 @@ namespace Palworld {
 
         void EditTranslations(const RC::Unreal::FName& CharacterId, const nlohmann::json& Data);
 
-        RC::Unreal::UDataTable* m_monsterDataTable;
-        RC::Unreal::UDataTable* m_iconDataTable;
-        RC::Unreal::UDataTable* m_palBpClassTable;
-        RC::Unreal::UDataTable* m_wazaMasterLevelTable;
-        RC::Unreal::UDataTable* m_palDropItemTable;
-        RC::Unreal::UDataTable* m_palNameTable;
-        RC::Unreal::UDataTable* m_palShortDescTable;
-        RC::Unreal::UDataTable* m_palLongDescTable;
+        RC::Unreal::UDataTable* m_monsterDataTable{};
+        RC::Unreal::UDataTable* m_iconDataTable{};
+        RC::Unreal::UDataTable* m_palBpClassTable{};
+        RC::Unreal::UDataTable* m_wazaMasterLevelTable{};
+        RC::Unreal::UDataTable* m_palDropItemTable{};
+        RC::Unreal::UDataTable* m_palNameTable{};
+        RC::Unreal::UDataTable* m_palShortDescTable{};
+        RC::Unreal::UDataTable* m_palLongDescTable{};
+
+        RC::Unreal::UClass* m_spawnItemBaseClass{};
+        RC::Unreal::TSet<RC::Unreal::FName> m_defaultFarmPals;
     };
 }

--- a/include/Loader/PalMonsterModLoader.h
+++ b/include/Loader/PalMonsterModLoader.h
@@ -56,6 +56,7 @@ namespace Palworld {
         RC::Unreal::UDataTable* m_palLongDescTable{};
 
         RC::Unreal::UClass* m_spawnItemBaseClass{};
+        RC::Unreal::TMap<RC::Unreal::FName, RC::Unreal::UClass*> m_cachedSpawnItemActionsByName;
         RC::Unreal::TSet<RC::Unreal::FName> m_defaultFarmPals;
     };
 }

--- a/include/SDK/Classes/Custom/UBlueprintGeneratedClass.h
+++ b/include/SDK/Classes/Custom/UBlueprintGeneratedClass.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Unreal/CoreUObject/UObject/Class.hpp"
+#include "SDK/Classes/Custom/UClassWrapper.h"
 #include "SDK/Classes/Custom/USimpleConstructionScript.h"
 
 namespace RC::Unreal {
@@ -10,8 +10,12 @@ namespace RC::Unreal {
 namespace UECustom {
     class UInheritableComponentHandler;
 
-    class UBlueprintGeneratedClass : public RC::Unreal::UClass {
+    class UBlueprintGeneratedClass : public UECustom::UClassWrapper {
     public:
+        static RC::Unreal::UClass* StaticClass();
+
+        void PurgeClass(bool bRecompilingOnLoad);
+
         UInheritableComponentHandler* GetInheritableComponentHandler();
 
         USimpleConstructionScript* GetSimpleConstructionScript();

--- a/include/SDK/Classes/Custom/UClassWrapper.h
+++ b/include/SDK/Classes/Custom/UClassWrapper.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Unreal/CoreUObject/UObject/Class.hpp"
+
+namespace UECustom {
+    class UClassWrapper : public RC::Unreal::UClass {
+    public:
+        RC::Unreal::UObject* GetDefaultObject(bool bCreateIfNeeded = true);
+
+        // bForce Assemble the stream even if it has been already assembled (deletes the old one)
+        void AssembleReferenceTokenStream(bool bForce = false);
+
+        void StaticLink(bool bRelinkExistingProperties);
+    };
+}

--- a/include/SDK/Classes/KismetSystemLibrary.h
+++ b/include/SDK/Classes/KismetSystemLibrary.h
@@ -12,7 +12,9 @@ namespace UECustom {
 
 		static FSoftObjectPath MakeSoftObjectPath(const RC::Unreal::FString& Path);
 
-		static RC::Unreal::UObject* LoadAsset_Blocking(UECustom::TSoftObjectPtr<RC::Unreal::UObject> Asset);
+		static RC::Unreal::UObject* LoadAsset_Blocking(UECustom::TSoftObjectPtr<RC::Unreal::UObject> Asset, bool bSetRootSet = false);
+
+		static RC::Unreal::UObject* LoadAsset_Blocking(const RC::StringType& AssetPath, bool bSetRootSet = false);
 	private:
 		static UKismetSystemLibrary* GetDefaultObj();
 	};

--- a/include/SDK/Helper/BPGeneratedClassHelper.h
+++ b/include/SDK/Helper/BPGeneratedClassHelper.h
@@ -6,7 +6,14 @@ namespace RC::Unreal {
     class UObject;
 }
 
+namespace UECustom {
+    class UBlueprintGeneratedClass;
+}
+
 namespace UECustom::BPGeneratedClassHelper {
+    UECustom::UBlueprintGeneratedClass* CreateInheritedBlueprintClass(RC::Unreal::UClass* parentClass, const RC::Unreal::FName& packageName,
+                                                                     const RC::Unreal::FName& assetName, RC::Unreal::EObjectFlags objectFlags);
+
     RC::Unreal::UObject* FindComponentTemplateByName(RC::Unreal::UObject* BPGeneratedClass, RC::Unreal::FName TemplateName);
 
     bool GetGeneratedClassesHierarchy(RC::Unreal::UClass* InClass, RC::Unreal::TArray<RC::Unreal::UObject*>& OutBPGClasses);

--- a/include/SDK/Helper/Memory.h
+++ b/include/SDK/Helper/Memory.h
@@ -2,7 +2,12 @@
 
 #include "Helpers/String.hpp"
 
+namespace RC::Unreal {
+    class UClass;
+}
+
 namespace Palworld {
     uintptr_t** GetVTablePtrByClassPath(const RC::StringType& classPath);
+    void* GetVirtualFunctionFromClass(RC::Unreal::UClass* targetClass, size_t offset);
     void* GetVirtualFunctionFromVTable(uintptr_t** vtable, size_t offset);
 }

--- a/include/SDK/PalSignatures.h
+++ b/include/SDK/PalSignatures.h
@@ -23,6 +23,9 @@ namespace Palworld {
             { "AsyncTask", "48 8B C4 41 54 41 57 48 81 EC B8 00 00 00 48 89 58 08" },
             // Used to initialize any other loader logic like pals, items, etc
             { "AGameModeBase::InitGameState", "40 53 48 83 EC 20 48 8B 41 10 48 8B D9 48 8B 91 F0 02 00 00" },
+            { "UClass::AssembleReferenceTokenStream", "48 8B C4 55 56 48 8D 68 A1 48 81 EC A8 00 00 00 48 89 58 10 48 8D B1 F8 01 00 00" },
+            { "UClass::GetDefaultObject", "40 53 48 83 EC 20 48 83 B9 10 01 00 00 00 48 8B D9 75 1A 84 D2 74 16 48 8B 01" },
+            { "UStruct::StaticLink", "48 89 5C 24 08 57 48 81 EC C0 00 00 00 48 8B F9 0F B6 DA 48 8D 4C 24 20" },
             // UE4SS has StaticFindObject, but this lets us use it earlier.
             { "UObjectGlobals::StaticFindObject", "48 8B C4 48 89 58 08 48 89 68 18 48 89 70 20 57 41 56 41 57 48 83 EC 60 48 83 FA FF" },
             // I had issues using the IsA provided by UE4SS due to early init, so I switched to using Unreal's own.

--- a/include/Utility/EnumHelpers.h
+++ b/include/Utility/EnumHelpers.h
@@ -9,4 +9,7 @@ namespace RC::Unreal {
 
 namespace PS::EnumHelpers {
     RC::Unreal::int64 GetEnumValueByName(RC::Unreal::UEnum* enum_, const std::string& enumString);
+
+    // Expects the enum name to be in the following format: Namespace::Name, e.g. EPalWazaID::TidalWave
+    RC::Unreal::int64 GetEnumValueByName(RC::Unreal::UEnum* enumClass, const RC::Unreal::FName& enumName);
 }

--- a/src/Loader/PalMonsterModLoader.cpp
+++ b/src/Loader/PalMonsterModLoader.cpp
@@ -56,7 +56,7 @@ namespace Palworld {
         {
             m_monsterDataTable = GetDatatableByName("DT_PalMonsterParameter");
             m_iconDataTable = GetDatatableByName("DT_PalCharacterIconDataTable");
-            m_palBpClassTable = GetDatatableByName("DT_PalCharacterIconDataTable");
+            m_palBpClassTable = GetDatatableByName("DT_PalBPClass");
             m_wazaMasterLevelTable = GetDatatableByName("DT_WazaMasterLevel");
             m_palDropItemTable = GetDatatableByName("DT_PalDropItem");
             m_palNameTable = GetDatatableByName("DT_PalNameText");

--- a/src/Loader/PalMonsterModLoader.cpp
+++ b/src/Loader/PalMonsterModLoader.cpp
@@ -1,15 +1,19 @@
-#include "Unreal/UObjectGlobals.hpp"
-#include "Unreal/UScriptStruct.hpp"
-#include "Unreal/FProperty.hpp"
+#include "Unreal/CoreUObject/UObject/UnrealType.hpp"
+#include "Unreal/Property/FEnumProperty.hpp"
 #include "Unreal/Engine/UDataTable.hpp"
 #include "SDK/Classes/KismetInternationalizationLibrary.h"
+#include "SDK/Classes/Custom/UObjectGlobals.h"
 #include "SDK/Structs/FPalCharacterIconDataRow.h"
 #include "SDK/Structs/FPalBPClassDataRow.h"
 #include "SDK/Helper/PropertyHelper.h"
 #include "Utility/Logging.h"
 #include "Utility/JsonHelpers.h"
+#include "Utility/EnumHelpers.h"
 #include "Helpers/String.hpp"
 #include "Loader/PalMonsterModLoader.h"
+#include "SDK/Classes/KismetSystemLibrary.h"
+#include "SDK/Classes/Custom/UBlueprintGeneratedClass.h"
+#include "SDK/Helper/BPGeneratedClassHelper.h"
 
 using namespace RC;
 using namespace RC::Unreal;
@@ -62,6 +66,18 @@ namespace Palworld {
             m_palNameTable = GetDatatableByName("DT_PalNameText");
             m_palShortDescTable = GetDatatableByName("DT_PalShortDescriptionText");
             m_palLongDescTable = GetDatatableByName("DT_PalLongDescriptionText");
+
+            auto assetPath = TEXT("/Game/Pal/Blueprint/Action/Common/SpawnItem/Base/BP_Action_SpawnItemBase.BP_Action_SpawnItemBase_C");
+            auto softObjectPtr = UECustom::TSoftObjectPtr<UObject>(UECustom::FSoftObjectPath(assetPath));
+            auto loadedAsset = static_cast<UClass*>(UECustom::UKismetSystemLibrary::LoadAsset_Blocking(softObjectPtr));
+            if (!loadedAsset)
+            {
+                throw std::runtime_error(RC::fmt("Asset '%S' was invalid", assetPath));
+            }
+            loadedAsset->SetRootSet();
+            m_spawnItemBaseClass = loadedAsset;
+
+            InitializeDefaultRanchPalsList();
         }
         catch (const std::exception& e)
         {
@@ -70,6 +86,42 @@ namespace Palworld {
         }
 
         return true;
+    }
+
+    RC::Unreal::UObject* PalMonsterModLoader::CreateSpawnItemActionByCharacterId(const RC::Unreal::FName& characterId)
+    {
+        if (!m_spawnItemBaseClass)
+        {
+            PS::Log<LogLevel::Error>(
+                TEXT("Unable to create a Spawn Item Action Class for {}, because base spawn item class was invalid.\n"), characterId.ToString());
+            return nullptr;
+        }
+
+        auto newPackageName = FName(std::format(TEXT("/PalSchema/SpawnItem/BP_Action_SpawnItem_{}"), characterId.ToString()));
+        auto newAssetName = FName(std::format(TEXT("BP_Action_SpawnItem_{}_C"), characterId.ToString()));
+        auto objectFlags = static_cast<EObjectFlags>(RF_Public | RF_Transient);
+        auto newBPClass = UECustom::BPGeneratedClassHelper::CreateInheritedBlueprintClass(m_spawnItemBaseClass, newPackageName, newAssetName, objectFlags);
+
+        auto cdo = newBPClass->GetDefaultObject(true);
+        cdo->SetRootSet();
+
+        return cdo;
+    }
+
+    void PalMonsterModLoader::InitializeDefaultRanchPalsList()
+    {
+        auto& paramMap = m_monsterDataTable->GetRowMap();
+        auto paramRowStruct = m_monsterDataTable->GetRowStruct().Get();
+
+        for (auto& [key, value] : paramMap)
+        {
+            auto farmProperty = PropertyHelper::GetPropertyByName(paramRowStruct, TEXT("WorkSuitability_MonsterFarm"));
+            auto farmValue = *farmProperty->ContainerPtrToValuePtr<int>(value);
+            if (farmValue > 0)
+            {
+                m_defaultFarmPals.Add(key);
+            }
+        }
     }
 
     void PalMonsterModLoader::LoadPals(const nlohmann::json& data)
@@ -158,7 +210,7 @@ namespace Palworld {
 			}
 			else if (KeyName == STR("ActorClassPath"))
 			{
-				auto BlueprintTableRow = std::bit_cast<FPalBPClassDataRow*>(m_palBpClassTable->FindRowUnchecked(CharacterId));
+                auto BlueprintTableRow = std::bit_cast<FPalBPClassDataRow*>(m_palBpClassTable->FindRowUnchecked(CharacterId));
 				if (BlueprintTableRow)
 				{
 					auto BlueprintPath = RC::to_generic_string(value.get<std::string>());
@@ -179,8 +231,82 @@ namespace Palworld {
 			}
 		}
 
+        HandleRanchSuitability(TableRow, CharacterId, properties);
 		EditTranslations(CharacterId, properties);
 	}
+
+    void PalMonsterModLoader::HandleRanchSuitability(uint8_t* row, const RC::Unreal::FName& characterId, const nlohmann::json& data)
+    {
+        // Skip pals that already have ranch suitability in the base game.
+        if (m_defaultFarmPals.Contains(characterId)) return;
+
+        auto rowStruct = m_monsterDataTable->GetRowStruct().Get();
+        auto ranchSuitabilityProperty = PropertyHelper::GetPropertyByName(rowStruct, TEXT("WorkSuitability_MonsterFarm"));
+        auto ranchSuitability = *ranchSuitabilityProperty->ContainerPtrToValuePtr<int>(row);
+
+        if (ranchSuitability <= 0 || !data.contains("RanchActionData")) return;
+
+        auto& ranchActionData = data.at("RanchActionData");
+        if (!ranchActionData.is_object())
+        {
+            PS::Log<LogLevel::Error>(
+                TEXT("Unable to create a Spawn Item Action Class for {}, field 'RanchActionData' must be an object."), characterId.ToString());
+            return;
+        }
+
+        auto bpCharacterRow = std::bit_cast<FPalBPClassDataRow*>(m_palBpClassTable->FindRowUnchecked(characterId));
+        if (!bpCharacterRow)
+        {
+            PS::Log<LogLevel::Error>(
+                TEXT("Unable to create a Spawn Item Action Class for {}, DT_PalBPClass doesn't have a row for this pal."), characterId.ToString());
+            return;
+        }
+
+        auto bpCharacterPath = UECustom::TSoftObjectPtr<UObject>(UECustom::FSoftObjectPath(bpCharacterRow->BPClass.ToSoftObjectPath()));
+        auto bpCharacterClass = static_cast<UClass*>(UECustom::UKismetSystemLibrary::LoadAsset_Blocking(bpCharacterPath, true));
+        if (!bpCharacterClass)
+        {
+            PS::Log<LogLevel::Error>(
+                TEXT("Unable to create a Spawn Item Action Class for {}, failed to load character blueprint."), characterId.ToString());
+            return;
+        }
+
+        auto bpCharacterCDO = static_cast<UObject*>(bpCharacterClass->GetClassDefaultObject().Get());
+        auto actionComponentProp = PropertyHelper::GetPropertyByName(bpCharacterClass, TEXT("ActionComponent"));
+        if (!actionComponentProp)
+        {
+            PS::Log<LogLevel::Error>(
+                TEXT("Unable to create a Spawn Item Action Class for {}, failed to get 'ActionComponent' property."), characterId.ToString());
+            return;
+        }
+
+        auto actionComponent = *actionComponentProp->ContainerPtrToValuePtr<UObject*>(bpCharacterCDO);
+        if (!actionComponent) return;
+
+        auto actionMapProp = static_cast<FMapProperty*>(PropertyHelper::GetPropertyByName(actionComponent->GetClassPrivate(), TEXT("ActionMap")));
+        auto& actionMap = *actionMapProp->ContainerPtrToValuePtr<TMap<uint8_t, UClass*>>(actionComponent);
+
+        auto newSpawnAction = CreateSpawnItemActionByCharacterId(characterId);
+        if (!newSpawnAction) return;
+
+        const std::vector<std::string> validPropertyNames = { "ChargeMontage", "FunMontage", "ChargeFacialEye", "FunFacialEye", "SpawnSocketName",
+                                                              "SpawnLocationOffset", "SpawnItemRotator" };
+
+        for (auto& propertyName : validPropertyNames)
+        {
+            if (!ranchActionData.contains(propertyName)) continue;
+
+            auto propertyNameWide = RC::to_generic_string(propertyName);
+            auto property = PropertyHelper::GetPropertyByName(newSpawnAction->GetClassPrivate(), propertyNameWide.c_str());
+            PropertyHelper::CopyJsonValueToContainer(newSpawnAction, property, ranchActionData.at(propertyName));
+        }
+
+        auto actionMapKeyProp = static_cast<FEnumProperty*>(actionMapProp->GetKeyProp());
+        auto spawnItemEnumValue = PS::EnumHelpers::GetEnumValueByName(actionMapKeyProp->GetEnum(), FName(TEXT("EPalActionType::SpawnItem")));
+        actionMap.Add(static_cast<uint8>(spawnItemEnumValue), newSpawnAction->GetClassPrivate());
+        
+        PS::Log<LogLevel::Normal>(STR("Added SpawnItem action for {}\n"), characterId.ToString());
+    }
 
 	void PalMonsterModLoader::AddIcon(const RC::Unreal::FName& CharacterId, const RC::StringType& IconPath)
 	{

--- a/src/Loader/PalMonsterModLoader.cpp
+++ b/src/Loader/PalMonsterModLoader.cpp
@@ -99,11 +99,19 @@ namespace Palworld {
 
         auto newPackageName = FName(std::format(TEXT("/PalSchema/SpawnItem/BP_Action_SpawnItem_{}"), characterId.ToString()));
         auto newAssetName = FName(std::format(TEXT("BP_Action_SpawnItem_{}_C"), characterId.ToString()));
+
+        if (auto cachedSpawnItemActionClass = m_cachedSpawnItemActionsByName.Find(newAssetName))
+        {
+            return (*cachedSpawnItemActionClass)->GetClassDefaultObject();
+        }
+
         auto objectFlags = static_cast<EObjectFlags>(RF_Public | RF_Transient);
         auto newBPClass = UECustom::BPGeneratedClassHelper::CreateInheritedBlueprintClass(m_spawnItemBaseClass, newPackageName, newAssetName, objectFlags);
 
         auto cdo = newBPClass->GetDefaultObject(true);
         cdo->SetRootSet();
+
+        m_cachedSpawnItemActionsByName.Add(newAssetName, newBPClass);
 
         return cdo;
     }

--- a/src/SDK/Classes/Custom/UBlueprintGeneratedClass.cpp
+++ b/src/SDK/Classes/Custom/UBlueprintGeneratedClass.cpp
@@ -1,12 +1,44 @@
 #include "SDK/Classes/Custom/UBlueprintGeneratedClass.h"
 #include "SDK/Classes/Custom/UInheritableComponentHandler.h"
-#include "Unreal/CoreUObject/UObject/UnrealType.hpp"
-#include "SDK/Classes/Custom/UObjectWrapper.h"
+#include "SDK/Classes/Custom/UObjectGlobals.h"
+#include "SDK/Helper/Memory.h"
 #include "SDK/Helper/PropertyHelper.h"
+#include "SDK/PalSignatures.h"
+#include "Utility/Logging.h"
+#include "Unreal/CoreUObject/UObject/UnrealType.hpp"
 
 using namespace Palworld;
+using namespace RC;
+using namespace RC::Unreal;
 
 namespace UECustom {
+    RC::Unreal::UClass* UBlueprintGeneratedClass::StaticClass()
+    {
+        static auto Class = UECustom::UObjectGlobals::StaticFindObject<UClass*>(nullptr, nullptr, TEXT("/Script/Engine.BlueprintGeneratedClass"));
+        return Class;
+    }
+
+    void UBlueprintGeneratedClass::PurgeClass(bool bRecompilingOnLoad)
+    {
+        using FnSignature = void(*)(UClass*, bool);
+        static FnSignature fn = nullptr;
+
+        if (!fn)
+        {
+            auto staticClass = StaticClass();
+            auto fnAddress = Palworld::GetVirtualFunctionFromClass(staticClass, 120);
+            fn = static_cast<FnSignature>(fnAddress);
+        }
+
+        if (!fn)
+        {
+            PS::Log<LogLevel::Error>(STR("Failed to call UBlueprintGeneratedClass::PurgeClass because function address was invalid.\n"));
+            return;
+        }
+
+        fn(this, bRecompilingOnLoad);
+    }
+
     UInheritableComponentHandler* UBlueprintGeneratedClass::GetInheritableComponentHandler()
     {
         auto InheritableComponentHandler = 

--- a/src/SDK/Classes/Custom/UClassWrapper.cpp
+++ b/src/SDK/Classes/Custom/UClassWrapper.cpp
@@ -1,0 +1,73 @@
+#include "SDK/Classes/Custom/UClassWrapper.h"
+#include "SDK/Helper/Memory.h"
+#include "SDK/PalSignatures.h"
+#include "Utility/Logging.h"
+
+using namespace Palworld;
+using namespace RC;
+using namespace RC::Unreal;
+
+namespace UECustom {
+    RC::Unreal::UObject* UClassWrapper::GetDefaultObject(bool bCreateIfNeeded)
+    {
+        using FnSignature = RC::Unreal::UObject* (*)(UClass*, bool);
+        static FnSignature fn = nullptr;
+
+        if (!fn)
+        {
+            fn = reinterpret_cast<FnSignature>(
+                Palworld::SignatureManager::GetSignature("UClass::GetDefaultObject")
+            );
+        }
+
+        if (!fn)
+        {
+            PS::Log<LogLevel::Error>(STR("Failed to call UClass::GetDefaultObject because function address was invalid.\n"));
+            return nullptr;
+        }
+
+        return fn(this, bCreateIfNeeded);
+    }
+
+    void UClassWrapper::AssembleReferenceTokenStream(bool bForce)
+    {
+        using FnSignature = void(*)(UClass*, bool);
+        static FnSignature fn = nullptr;
+
+        if (!fn)
+        {
+            fn = reinterpret_cast<FnSignature>(
+                Palworld::SignatureManager::GetSignature("UClass::AssembleReferenceTokenStream")
+            );
+        }
+
+        if (!fn)
+        {
+            PS::Log<LogLevel::Error>(STR("Failed to call UClass::AssembleReferenceTokenStream because function address was invalid.\n"));
+            return;
+        }
+
+        fn(this, bForce);
+    }
+
+    void UClassWrapper::StaticLink(bool bRelinkExistingProperties)
+    {
+        using FnSignature = void(*)(UClass*, bool);
+        static FnSignature fn = nullptr;
+
+        if (!fn)
+        {
+            fn = reinterpret_cast<FnSignature>(
+                Palworld::SignatureManager::GetSignature("UStruct::StaticLink")
+            );
+        }
+
+        if (!fn)
+        {
+            PS::Log<LogLevel::Error>(STR("Failed to call UStruct::StaticLink because function address was invalid.\n"));
+            return;
+        }
+
+        fn(this, bRelinkExistingProperties);
+    }
+}

--- a/src/SDK/Classes/KismetSystemLibrary.cpp
+++ b/src/SDK/Classes/KismetSystemLibrary.cpp
@@ -42,7 +42,7 @@ namespace UECustom {
 		return params.ReturnValue;
 	}
 
-    RC::Unreal::UObject* UKismetSystemLibrary::LoadAsset_Blocking(UECustom::TSoftObjectPtr<UObject> Asset)
+    RC::Unreal::UObject* UKismetSystemLibrary::LoadAsset_Blocking(UECustom::TSoftObjectPtr<UObject> Asset, bool bSetRootSet)
     {
         static auto Function = UECustom::UObjectGlobals::StaticFindObject<UFunction*>(nullptr, nullptr, TEXT("/Script/Engine.KismetSystemLibrary:LoadAsset_Blocking"));
 
@@ -61,7 +61,19 @@ namespace UECustom {
 
         GetDefaultObj()->ProcessEvent(Function, &params);
 
+        if (params.ReturnValue && bSetRootSet)
+        {
+            params.ReturnValue->SetRootSet();
+        }
+
         return params.ReturnValue;
+    }
+
+    RC::Unreal::UObject* UKismetSystemLibrary::LoadAsset_Blocking(const RC::StringType& AssetPath, bool bSetRootSet)
+    {
+        auto SoftObjectPtr = UECustom::TSoftObjectPtr<UObject>(UECustom::FSoftObjectPath(AssetPath));
+        auto LoadedAsset = LoadAsset_Blocking(SoftObjectPtr, bSetRootSet);
+        return LoadedAsset;
     }
 
 	UKismetSystemLibrary* UKismetSystemLibrary::GetDefaultObj()

--- a/src/SDK/Helper/BPGeneratedClassHelper.cpp
+++ b/src/SDK/Helper/BPGeneratedClassHelper.cpp
@@ -1,41 +1,67 @@
+#include "Unreal/CoreUObject/UObject/UnrealType.hpp"
+#include "Unreal/UPackage.hpp"
 #include "SDK/Helper/BPGeneratedClassHelper.h"
 #include "SDK/PalSignatures.h"
+#include "SDK/Classes/Custom/UBlueprintGeneratedClass.h"
 
 using namespace RC;
 using namespace RC::Unreal;
 
-UObject* UECustom::BPGeneratedClassHelper::FindComponentTemplateByName(UObject* BPGeneratedClass, FName TemplateName)
-{
-    using FindComponentTemplateByNameSignature = UObject*(*)(UObject*, const FName&);
-    static void* FunctionPtr = nullptr;
-
-    if (!FunctionPtr)
+namespace UECustom::BPGeneratedClassHelper {
+    UECustom::UBlueprintGeneratedClass* CreateInheritedBlueprintClass(RC::Unreal::UClass* parentClass, const RC::Unreal::FName& packageName,
+        const RC::Unreal::FName& assetName, RC::Unreal::EObjectFlags objectFlags)
     {
-        FunctionPtr = Palworld::SignatureManager::GetSignature("UBlueprintGeneratedClass::FindComponentTemplateByName");
+        auto newPackage = UObjectGlobals::NewObject<UPackage>(nullptr, packageName, static_cast<EObjectFlags>(RF_Public));
+        newPackage->SetRootSet();
+
+        auto newBlueprintClass = UObjectGlobals::NewObject<UECustom::UBlueprintGeneratedClass>(newPackage, assetName, objectFlags);
+        newBlueprintClass->PurgeClass(false);
+        newBlueprintClass->GetClassFlags() |= CLASS_Transient;
+        newBlueprintClass->GetClassWithin() = parentClass->GetClassWithin();
+        newBlueprintClass->GetPropertyLink() = parentClass->GetPropertyLink();
+        newBlueprintClass->SetSuperStruct(parentClass);
+        newBlueprintClass->Bind();
+        newBlueprintClass->StaticLink(true);
+        newBlueprintClass->AssembleReferenceTokenStream(false);
+        newBlueprintClass->SetRootSet();
+
+        return newBlueprintClass;
     }
 
-    if (!FunctionPtr)
+    UObject* UECustom::BPGeneratedClassHelper::FindComponentTemplateByName(UObject* BPGeneratedClass, FName TemplateName)
     {
-        return nullptr;
+        using FindComponentTemplateByNameSignature = UObject * (*)(UObject*, const FName&);
+        static void* FunctionPtr = nullptr;
+
+        if (!FunctionPtr)
+        {
+            FunctionPtr = Palworld::SignatureManager::GetSignature("UBlueprintGeneratedClass::FindComponentTemplateByName");
+        }
+
+        if (!FunctionPtr)
+        {
+            return nullptr;
+        }
+
+        return reinterpret_cast<FindComponentTemplateByNameSignature>(FunctionPtr)(BPGeneratedClass, TemplateName);
     }
 
-    return reinterpret_cast<FindComponentTemplateByNameSignature>(FunctionPtr)(BPGeneratedClass, TemplateName);
-}
-
-bool UECustom::BPGeneratedClassHelper::GetGeneratedClassesHierarchy(UClass* InClass, TArray<UObject*>& OutBPGClasses)
-{
-    using GetGeneratedClassesHierarchySignature = bool(*)(UClass*, TArray<UObject*>&);
-    static void* FunctionPtr = nullptr;
-
-    if (!FunctionPtr)
+    bool UECustom::BPGeneratedClassHelper::GetGeneratedClassesHierarchy(UClass* InClass, TArray<UObject*>& OutBPGClasses)
     {
-        FunctionPtr = Palworld::SignatureManager::GetSignature("UBlueprintGeneratedClass::FindComponentTemplateByName");
+        using GetGeneratedClassesHierarchySignature = bool(*)(UClass*, TArray<UObject*>&);
+        static void* FunctionPtr = nullptr;
+
+        if (!FunctionPtr)
+        {
+            FunctionPtr = Palworld::SignatureManager::GetSignature("UBlueprintGeneratedClass::FindComponentTemplateByName");
+        }
+
+        if (!FunctionPtr)
+        {
+            return false;
+        }
+
+        return reinterpret_cast<GetGeneratedClassesHierarchySignature>(FunctionPtr)(InClass, OutBPGClasses);
     }
 
-    if (!FunctionPtr)
-    {
-        return false;
-    }
-
-    return reinterpret_cast<GetGeneratedClassesHierarchySignature>(FunctionPtr)(InClass, OutBPGClasses);
 }

--- a/src/SDK/Helper/Memory.cpp
+++ b/src/SDK/Helper/Memory.cpp
@@ -27,6 +27,21 @@ namespace Palworld {
         return vtablePtr;
     }
 
+    void* GetVirtualFunctionFromClass(RC::Unreal::UClass* targetClass, size_t offset)
+    {
+        auto& cdo = targetClass->GetClassDefaultObject();
+        if (!cdo)
+        {
+            PS::Log<LogLevel::Error>(STR("Unable to get VTable pointer for {}, class default object not found.\n"), targetClass->GetFullName());
+            return nullptr;
+        }
+
+        uintptr_t** vtablePtr = *(uintptr_t***)cdo;
+        void* vfuncptr = (void*)vtablePtr[offset];
+
+        return vfuncptr;
+    }
+
     void* GetVirtualFunctionFromVTable(uintptr_t** vtable, size_t offset)
     {
         void* vfuncptr = (void*)vtable[offset];

--- a/src/SDK/Helper/PropertyHelper.cpp
+++ b/src/SDK/Helper/PropertyHelper.cpp
@@ -21,6 +21,11 @@ using namespace RC::Unreal;
 namespace Palworld {
     void PropertyHelper::CopyJsonValueToContainer(void* Container, FProperty* Property, const nlohmann::json& Value)
     {
+        if (!Property)
+        {
+            throw std::runtime_error("A null Property was supplied to PropertyHelper::CopyJsonValueToContainer.");
+        }
+
         auto PropertyName = Property->GetName();
         auto Type = Property->GetCPPType();
         auto Class = Property->GetClass();
@@ -261,23 +266,38 @@ namespace Palworld {
     {
         ValidateJsonValueType(Property, Value);
 
-        auto ParsedValue = Value.get<nlohmann::json>();
-        auto ObjectValue = *Property->ContainerPtrToValuePtr<UObject*>(Data);
-        if (ObjectValue)
+        if (Value.is_string())
         {
-            for (auto& [InnerKey, InnerValue] : Value.items())
+            auto StringValue = Value.get<std::string>();
+            auto WideStringValue = RC::to_generic_string(StringValue);
+            auto LoadedObject = UECustom::UKismetSystemLibrary::LoadAsset_Blocking(WideStringValue, true);
+            if (!LoadedObject)
             {
-                auto ObjectValue_PropertyName = RC::to_generic_string(InnerKey);
-                auto ObjectValue_Property = ObjectValue->GetPropertyByNameInChain(ObjectValue_PropertyName.c_str());
-
-                if (!ObjectValue_Property)
+                PS::Log<LogLevel::Error>(STR("Unable to apply changes to {} because provided asset was invalid.\n"), Property->GetName());
+                return;
+            }
+            *Property->ContainerPtrToValuePtr<UObject*>(Data) = LoadedObject;
+        }
+        else if (Value.is_object())
+        {
+            auto ObjectValue = *Property->ContainerPtrToValuePtr<UObject*>(Data);
+            auto ParsedValue = Value.get<nlohmann::json>();
+            if (ObjectValue)
+            {
+                for (auto& [InnerKey, InnerValue] : Value.items())
                 {
-                    ObjectValue_Property = Palworld::PropertyHelper::GetPropertyByName(ObjectValue->GetClassPrivate(), ObjectValue_PropertyName);
-                }
+                    auto ObjectValue_PropertyName = RC::to_generic_string(InnerKey);
+                    auto ObjectValue_Property = ObjectValue->GetPropertyByNameInChain(ObjectValue_PropertyName.c_str());
 
-                if (ObjectValue_Property)
-                {
-                    CopyJsonValueToContainer(ObjectValue, ObjectValue_Property, InnerValue);
+                    if (!ObjectValue_Property)
+                    {
+                        ObjectValue_Property = Palworld::PropertyHelper::GetPropertyByName(ObjectValue->GetClassPrivate(), ObjectValue_PropertyName);
+                    }
+
+                    if (ObjectValue_Property)
+                    {
+                        CopyJsonValueToContainer(ObjectValue, ObjectValue_Property, InnerValue);
+                    }
                 }
             }
         }
@@ -474,7 +494,7 @@ namespace Palworld {
         }
         else if (auto ObjectProperty = CastProperty<FObjectProperty>(Property) && PropertyClassName == STR("ObjectProperty"))
         {
-            if (!Value.is_object()) throw std::runtime_error(std::format("Property {} must be an object", PropertyName));
+            if (!Value.is_object() && !Value.is_string()) throw std::runtime_error(std::format("Property {} must be an object or string", PropertyName));
         }
         else if (auto SoftObjectProperty = CastProperty<FSoftObjectProperty>(Property) && PropertyClassName == STR("SoftObjectProperty"))
         {

--- a/src/SDK/Helper/PropertyHelper.cpp
+++ b/src/SDK/Helper/PropertyHelper.cpp
@@ -273,9 +273,20 @@ namespace Palworld {
             auto LoadedObject = UECustom::UKismetSystemLibrary::LoadAsset_Blocking(WideStringValue, true);
             if (!LoadedObject)
             {
-                PS::Log<LogLevel::Error>(STR("Unable to apply changes to {} because provided asset was invalid.\n"), Property->GetName());
-                return;
+                throw std::runtime_error(RC::fmt("Unable to apply changes to %S. Asset was invalid.", Property->GetName().c_str()));
             }
+
+            auto& ExpectedClass = Property->GetPropertyClass();
+            if (!LoadedObject->IsA(ExpectedClass))
+            {
+                throw std::runtime_error(RC::fmt(
+                    "Unable to apply changes to %S. Asset didn't match the expected class for this property. Expected '%S', got '%S'", 
+                    Property->GetName().c_str(),
+                    ExpectedClass->GetName().c_str(),
+                    LoadedObject->GetClassPrivate()->GetName().c_str())
+                );
+            }
+
             *Property->ContainerPtrToValuePtr<UObject*>(Data) = LoadedObject;
         }
         else if (Value.is_object())

--- a/src/Utility/EnumHelpers.cpp
+++ b/src/Utility/EnumHelpers.cpp
@@ -29,4 +29,19 @@ namespace PS::EnumHelpers {
 
         return 0;
     }
+
+    RC::Unreal::int64 GetEnumValueByName(RC::Unreal::UEnum* enumClass, const RC::Unreal::FName& enumName)
+    {
+        for (const auto& enumPair : enumClass->GetEnumNames())
+        {
+            if (enumPair.Key == enumName)
+            {
+                return enumPair.Value;
+            }
+        }
+
+        PS::Log<LogLevel::Warning>(STR("Enum '{}' doesn't exist."), enumName.ToString());
+
+        return 0;
+    }
 }


### PR DESCRIPTION
Adds a convenience wrapper for pal loader that allows you to enable ranch suitability purely through json. Before you had to manually create a new SpawnItem blueprint in UE and then package it with your mod. I've included an example mod that showcases how to use this feature and you can find it under `assets/examples/CattivaRanchSuitability`.

Passing asset references to FObjectProperty is now possible which is also seen used in the CattivaRanchSuitability mod example found in `pals/pinkcat.jsonc` "ChargeMontage" and "FunMontage" fields.