### PR TITLE
Fix ranch spawn item actions not being created properly

### DIFF
--- a/include/Loader/PalMonsterModLoader.h
+++ b/include/Loader/PalMonsterModLoader.h
@@ -24,8 +24,6 @@ namespace Palworld {
         // Creates a new BP_Action_SpawnItem class and returns the class default object for it.
         RC::Unreal::UObject* CreateSpawnItemActionByCharacterId(const RC::Unreal::FName& characterId);
 
-        void InitializeDefaultRanchPalsList();
-
         void LoadPals(const nlohmann::json& data);
 
         void Add(const RC::Unreal::FName& CharacterId, const nlohmann::json& properties);
@@ -57,6 +55,5 @@ namespace Palworld {
 
         RC::Unreal::UClass* m_spawnItemBaseClass{};
         RC::Unreal::TMap<RC::Unreal::FName, RC::Unreal::UClass*> m_cachedSpawnItemActionsByName;
-        RC::Unreal::TSet<RC::Unreal::FName> m_defaultFarmPals;
     };
 }

--- a/src/Loader/PalMonsterModLoader.cpp
+++ b/src/Loader/PalMonsterModLoader.cpp
@@ -72,12 +72,10 @@ namespace Palworld {
             auto loadedAsset = static_cast<UClass*>(UECustom::UKismetSystemLibrary::LoadAsset_Blocking(softObjectPtr));
             if (!loadedAsset)
             {
-                throw std::runtime_error(RC::fmt("Asset '%S' was invalid", assetPath));
+                throw std::runtime_error(RC::fmt("Asset '%S' was invalid, unable to setup ranch suitabilities.", assetPath));
             }
             loadedAsset->SetRootSet();
             m_spawnItemBaseClass = loadedAsset;
-
-            InitializeDefaultRanchPalsList();
         }
         catch (const std::exception& e)
         {
@@ -114,22 +112,6 @@ namespace Palworld {
         m_cachedSpawnItemActionsByName.Add(newAssetName, newBPClass);
 
         return cdo;
-    }
-
-    void PalMonsterModLoader::InitializeDefaultRanchPalsList()
-    {
-        auto& paramMap = m_monsterDataTable->GetRowMap();
-        auto paramRowStruct = m_monsterDataTable->GetRowStruct().Get();
-
-        for (auto& [key, value] : paramMap)
-        {
-            auto farmProperty = PropertyHelper::GetPropertyByName(paramRowStruct, TEXT("WorkSuitability_MonsterFarm"));
-            auto farmValue = *farmProperty->ContainerPtrToValuePtr<int>(value);
-            if (farmValue > 0)
-            {
-                m_defaultFarmPals.Add(key);
-            }
-        }
     }
 
     void PalMonsterModLoader::LoadPals(const nlohmann::json& data)
@@ -245,14 +227,13 @@ namespace Palworld {
 
     void PalMonsterModLoader::HandleRanchSuitability(uint8_t* row, const RC::Unreal::FName& characterId, const nlohmann::json& data)
     {
-        // Skip pals that already have ranch suitability in the base game.
-        if (m_defaultFarmPals.Contains(characterId)) return;
+        if (!data.contains("RanchActionData")) return;
 
         auto rowStruct = m_monsterDataTable->GetRowStruct().Get();
         auto ranchSuitabilityProperty = PropertyHelper::GetPropertyByName(rowStruct, TEXT("WorkSuitability_MonsterFarm"));
         auto ranchSuitability = *ranchSuitabilityProperty->ContainerPtrToValuePtr<int>(row);
 
-        if (ranchSuitability <= 0 || !data.contains("RanchActionData")) return;
+        if (ranchSuitability <= 0) return;
 
         auto& ranchActionData = data.at("RanchActionData");
         if (!ranchActionData.is_object())
@@ -313,7 +294,7 @@ namespace Palworld {
         auto spawnItemEnumValue = PS::EnumHelpers::GetEnumValueByName(actionMapKeyProp->GetEnum(), FName(TEXT("EPalActionType::SpawnItem")));
         actionMap.Add(static_cast<uint8>(spawnItemEnumValue), newSpawnAction->GetClassPrivate());
         
-        PS::Log<LogLevel::Normal>(STR("Added SpawnItem action for {}\n"), characterId.ToString());
+        PS::Log<LogLevel::Verbose>(STR("Added Ranch SpawnItem action for {}\n"), characterId.ToString());
     }
 
 	void PalMonsterModLoader::AddIcon(const RC::Unreal::FName& CharacterId, const RC::StringType& IconPath)

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
  
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               6
-#define VERSION_REVISION            0
+#define VERSION_REVISION            1
 #define VERSION_BUILD               0
  
 #define VER_FILE_DESCRIPTION_STR    "PalSchema"


### PR DESCRIPTION
Ranch spawn item actions were not being properly created for non-ranch pals that had their ranch suitability assigned through raw tables due to the pal loader code assuming they had ranch suitability by default since those two loaders are separate and raw tables are processed first. 

This was slight over engineering on my part and I was essentially trying to prevent creation of spawn item actions for pals that already have ranch suitability by default to prevent issues, but I don't think it's that big of a deal now that I think about it.

Same rules still apply (in order): 
1. Must have "RanchActionData" specified
2. Must have a ranch suitability level of one or more.