### PR TITLE
Fix world corruption related to craft item counts with custom items

### DIFF
--- a/include/Loader/PalItemModLoader.h
+++ b/include/Loader/PalItemModLoader.h
@@ -44,23 +44,28 @@ namespace Palworld {
 
         void SetupHooks();
 
-		UPalStaticItemDataAsset* m_itemDataAsset{};
 		RC::Unreal::UDataTable* m_itemDataTable{};
 		RC::Unreal::UDataTable* m_itemRecipeTable{};
 		RC::Unreal::UDataTable* m_nameTranslationTable{};
 		RC::Unreal::UDataTable* m_descriptionTranslationTable{};
     private:
+        // DA_StaticItemDataAsset doesn't seem to ever unload, so it should be safe to store it in a static global.
+        static inline UPalStaticItemDataAsset* GItemDataAsset{};
+
         static inline void* ApplyItemSaveDataAddress = nullptr;
         static inline void* ApplyDynamicItemSaveDataAddress = nullptr;
+        static inline void* CraftItemCount_ApplyDataMapReturnAddress = nullptr;
         static inline SafetyHookInline UpdateItem_ServerInternalHook;
         static inline SafetyHookInline DynamicItemHook;
         static inline SafetyHookInline ValidateWorldSaveDynamicItemStaticIdsHook;
         static inline SafetyHookInline ValidateDynamicItemSaveDataHook;
+        static inline SafetyHookInline ApplyDataMapHook;
 
         static bool IsValidItem(RC::Unreal::UObject* worldContextObject, const RC::Unreal::FName& staticId);
         static void UpdateItem_Detour(RC::Unreal::UObject* self, FPalItemId* itemId, int amount, bool param4, bool param5);
         static UPalDynamicItemDataBase* CreateDynamicItemDatabase_Detour(RC::Unreal::UObject* self, FPalDynamicItemId* dynamicItemId, RC::Unreal::FName staticId, void* itemCreateParam);
         static bool ValidateWorldSaveDynamicItemStaticIds(RC::Unreal::UObject* idk, RC::Unreal::UObject* SaveGame, RC::Unreal::FString& idk3, RC::Unreal::FString& idk4);
         static bool ValidateDynamicItemSaveData(void* idk, RC::Unreal::UObject* DynamicItemDataBase, RC::Unreal::UObject* ItemIDManager, const RC::StringType& idk2);
+        static void FPalPlayerRecordDataRepInfoArrayThreadSafe_IntVal_ApplyDataMap(void* self, const RC::Unreal::TMap<RC::Unreal::FName, RC::Unreal::int32>& MapToApply);
 	};
 }

--- a/include/SDK/PalSignatures.h
+++ b/include/SDK/PalSignatures.h
@@ -38,6 +38,7 @@ namespace Palworld {
             { "UPalDynamicItemWorldSubsystem::ApplyWorldSaveData", "48 8B D8 48 8B 4C 24 50 48 85 C9 74 06 E8 ?? ?? ?? ?? 90 48 85 DB" },
             { "ValidateWorldSaveDynamicItemStaticIds", "48 89 5C 24 10 55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 60 FF FF FF 48 81 EC A0 01 00 00 48 8B ?? ?? ?? ?? ?? 48 33 C4 48 89 85 90 00 00 00 4D 8B E9" },
             { "ValidateDynamicItemSaveData", "40 55 53 56 57 41 54 41 56 41 57 48 8D AC 24 80 FE FF FF 48 81 EC 80 02 00 00 48 8B ?? ?? ?? ?? ?? 48 33 C4 48 89 85 70 01 00 00" },
+            { "CraftItemCount_ApplyDataMapReturn", "48 8B CB E8 ?? ?? ?? ?? 48 8B C8 48 89 45 77" },
         };
         static inline std::unordered_map<std::string, std::string> SignaturesCallResolve {
             // Don't ask, I know it's long..
@@ -53,6 +54,7 @@ namespace Palworld {
             { "UPalDynamicItemWorldSubsystem::Create_ServerInternal", "E8 ?? ?? ?? ?? 48 8B D8 48 8B 4C 24 50 48 85 C9 74 06 E8 ?? ?? ?? ?? 90 48 85 DB" },
             { "UPalItemSlot::UpdateItem_ServerInternal", "E8 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 48 89 5C 24 48" },
             { "UWorld::CleanupWorld", "E8 ?? ?? ?? ?? 8B 55 A7 FF C2 49 83 C5 08 89 55 A7" },
+            { "FPalPlayerRecordDataRepInfoArrayThreadSafe_IntVal::ApplyDataMap", "E8 ?? ?? ?? ?? 49 8D 95 F0 01 00 00 48 8D 8B 78 0B 00 00" },
         };
     };
 }

--- a/src/Loader/PalItemModLoader.cpp
+++ b/src/Loader/PalItemModLoader.cpp
@@ -62,7 +62,7 @@ namespace Palworld {
     {
         try
         {
-            m_itemDataAsset = UECustom::UObjectGlobals::StaticFindObject<UPalStaticItemDataAsset*>(nullptr, nullptr,
+            GItemDataAsset = UECustom::UObjectGlobals::StaticFindObject<UPalStaticItemDataAsset*>(nullptr, nullptr,
                 TEXT("/Game/Pal/DataAsset/Item/DA_StaticItemDataAsset.DA_StaticItemDataAsset"));
 
             m_itemDataTable = GetDatatableByName("DT_ItemDataTable");
@@ -86,11 +86,11 @@ namespace Palworld {
         for (auto& [key, value] : data.items())
         {
             auto itemId = FName(RC::to_generic_string(key), FNAME_Add);
-            auto row = m_itemDataAsset->StaticItemDataMap.Find(itemId);
+            auto row = GItemDataAsset->StaticItemDataMap.Find(itemId);
             if (value.is_null())
             {
                 if (!row) return;
-                m_itemDataAsset->StaticItemDataMap.Remove(itemId);
+                GItemDataAsset->StaticItemDataMap.Remove(itemId);
                 PS::Log<RC::LogLevel::Normal>(TEXT("Deleted Item '{}'\n"), itemId.ToString());
             }
             else
@@ -163,7 +163,7 @@ namespace Palworld {
 			throw std::runtime_error("Property 'DynamicItemDataClass' has changed in DA_StaticItemDataAsset. Update to Pal Schema is needed.");
 		}
 
-		FStaticConstructObjectParameters constructParams(databaseClass, m_itemDataAsset);
+		FStaticConstructObjectParameters constructParams(databaseClass, GItemDataAsset);
 		constructParams.Name = NAME_None;
 
 		auto item = UObjectGlobals::StaticConstructObject<UPalStaticItemDataBase*>(constructParams);
@@ -203,7 +203,7 @@ namespace Palworld {
 
 		AddTranslations(itemId, data);
 
-		m_itemDataAsset->StaticItemDataMap.Add(itemId, item);
+		GItemDataAsset->StaticItemDataMap.Add(itemId, item);
 	}
 
 	void PalItemModLoader::Edit(const RC::Unreal::FName& itemId, UPalStaticItemDataBase* item, const nlohmann::json& data)
@@ -462,6 +462,18 @@ namespace Palworld {
                 throw std::runtime_error("Signature for ValidateDynamicItemSaveData could not be found");
             }
 
+            auto address5 = Palworld::SignatureManager::GetSignature("FPalPlayerRecordDataRepInfoArrayThreadSafe_IntVal::ApplyDataMap");
+            if (!address5)
+            {
+                throw std::runtime_error("Signature for FPalPlayerRecordDataRepInfoArrayThreadSafe_IntVal::ApplyDataMap could not be found");
+            }
+
+            CraftItemCount_ApplyDataMapReturnAddress = Palworld::SignatureManager::GetSignature("CraftItemCount_ApplyDataMapReturn");
+            if (!CraftItemCount_ApplyDataMapReturnAddress)
+            {
+                throw std::runtime_error("Signature for CraftItemCount_ApplyDataMapReturn could not be found");
+            }
+
             UpdateItem_ServerInternalHook = safetyhook::create_inline(reinterpret_cast<void*>(address),
                 UpdateItem_Detour);
 
@@ -476,6 +488,9 @@ namespace Palworld {
 
             ValidateDynamicItemSaveDataHook = safetyhook::create_inline(reinterpret_cast<void*>(address4),
                 ValidateDynamicItemSaveData);
+
+            ApplyDataMapHook = safetyhook::create_inline(reinterpret_cast<void*>(address5),
+                FPalPlayerRecordDataRepInfoArrayThreadSafe_IntVal_ApplyDataMap);
         }
         catch (const std::exception& e)
         {
@@ -536,5 +551,31 @@ namespace Palworld {
     bool PalItemModLoader::ValidateDynamicItemSaveData(void* idk, UObject* DynamicItemDataBase, UObject* ItemIDManager, const RC::StringType& idk2)
     {
         return true;
+    }
+
+    void PalItemModLoader::FPalPlayerRecordDataRepInfoArrayThreadSafe_IntVal_ApplyDataMap(void* self, const RC::Unreal::TMap<RC::Unreal::FName, RC::Unreal::int32>& MapToApply)
+    {
+        /*
+        * This fixes crashing related to craft item counts in UPalUserAchievementChecker::CheckCraftCount for custom items that were uninstalled-
+        * but still exist in the save.
+        */
+
+        RC::Unreal::TMap<RC::Unreal::FName, RC::Unreal::int32> NewMap;
+        if (_ReturnAddress() == CraftItemCount_ApplyDataMapReturnAddress)
+        {
+            for (auto& [StaticItemId, Count] : MapToApply)
+            {
+                if (GItemDataAsset->StaticItemDataMap.Contains(StaticItemId))
+                {
+                    NewMap.Add(StaticItemId, Count);
+                }
+                else
+                {
+                    PS::Log<LogLevel::Warning>(TEXT("Item '{}' is invalid. Craft Item Count for this item will be deleted on next save.\n"), StaticItemId.ToString());
+                }
+            }
+        }
+
+        ApplyDataMapHook.call(self, NewMap);
     }
 }


### PR DESCRIPTION
Even with the safeguard for invalid custom item removal, worlds would still end up corrupted and this was related to craft item counts being stored for those custom items after they have been crafted.

This PR solves it by permanently deleting those counts for the custom items if the data for those items doesn't exist anymore, for example, if the mod adding those custom items was uninstalled and you try to load the world.

Manual save or autosave for the world needs to be triggered after loading for the removal to be permanent.