### PR TITLE
Fix record data reset

### DIFF
--- a/src/Loader/PalItemModLoader.cpp
+++ b/src/Loader/PalItemModLoader.cpp
@@ -585,10 +585,9 @@ namespace Palworld {
         * This fixes crashing related to craft item counts in UPalUserAchievementChecker::CheckCraftCount for custom items that were uninstalled-
         * but still exist in the save.
         */
-
-        RC::Unreal::TMap<RC::Unreal::FName, RC::Unreal::int32> NewMap;
         if (_ReturnAddress() == CraftItemCount_ApplyDataMapReturnAddress)
         {
+            RC::Unreal::TMap<RC::Unreal::FName, RC::Unreal::int32> NewMap;
             for (auto& [StaticItemId, Count] : MapToApply)
             {
                 if (GItemDataAsset->StaticItemDataMap.Contains(StaticItemId))
@@ -600,8 +599,12 @@ namespace Palworld {
                     PS::Log<LogLevel::Warning>(TEXT("Item '{}' is invalid. Craft Item Count for this item will be deleted on next save.\n"), StaticItemId.ToString());
                 }
             }
-        }
 
-        ApplyDataMapHook.call(self, NewMap);
+            ApplyDataMapHook.call(self, NewMap);
+        }
+        else
+        {
+            ApplyDataMapHook.call(self, MapToApply);
+        }
     }
 }

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
  
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               6
-#define VERSION_REVISION            2
+#define VERSION_REVISION            3
 #define VERSION_BUILD               0
  
 #define VER_FILE_DESCRIPTION_STR    "PalSchema"


### PR DESCRIPTION
I was accidentally passing an empty map onto every other record data that isn't related to items like Pal capture counts, which essentially resets all the record data causing issues like saddles showing up as question marks again in technology tree.