### PR TITLE
Fix new armor items not showing up in antique dresser

### DIFF
--- a/include/Loader/PalItemModLoader.h
+++ b/include/Loader/PalItemModLoader.h
@@ -40,7 +40,7 @@ namespace Palworld {
 		void EditTranslations(const RC::Unreal::FName& ItemId, const nlohmann::json& Data);
 
         // Handles DT_ItemDataTable stuff
-        void AddItemData(const RC::Unreal::FName& ItemId, const nlohmann::json& Data);
+        void AddItemData(const RC::Unreal::FName& ItemId, const RC::Unreal::FString& Type, const nlohmann::json& Data);
 
         void SetupHooks();
 

--- a/src/Loader/PalItemModLoader.cpp
+++ b/src/Loader/PalItemModLoader.cpp
@@ -207,7 +207,7 @@ namespace Palworld {
             AddRecipe(ItemId, Data.at("Recipe"));
         }
 
-        AddItemData(ItemId, Data);
+        AddItemData(ItemId, Type, Data);
 
         AddTranslations(ItemId, Data);
 
@@ -416,17 +416,9 @@ namespace Palworld {
 		}
 	}
 
-    void PalItemModLoader::AddItemData(const RC::Unreal::FName& ItemId, const nlohmann::json& Data)
+    void PalItemModLoader::AddItemData(const RC::Unreal::FName& ItemId, const FString& Type, const nlohmann::json& Data)
     {
         auto RowStruct = m_itemDataTable->GetRowStruct().Get();
-
-        auto LegalProp = RowStruct->GetPropertyByName(TEXT("bLegalInGame"));
-        if (!LegalProp)
-        {
-            PS::Log<LogLevel::Error>(TEXT("Property 'bLegalInGame' does not exist in DT_ItemDataTable, skipping addition of Data for {}.\n"), ItemId.ToString());
-            return;
-        }
-
         FManagedStruct RowData{ RowStruct };
 
         auto SortIdProp = RowStruct->GetPropertyByName(TEXT("SortID"));
@@ -434,15 +426,30 @@ namespace Palworld {
         {
             PropertyHelper::CopyJsonValueToContainer(RowData.GetData(), SortIdProp, Data.at("SortID"));
         }
-
-        if (Data.contains("bLegalInGame"))
+        else if (SortIdProp && Data.contains("SortId"))
         {
-            PropertyHelper::CopyJsonValueToContainer(RowData.GetData(), LegalProp, Data.at("bLegalInGame"));
+            PropertyHelper::CopyJsonValueToContainer(RowData.GetData(), SortIdProp, Data.at("SortId"));
         }
-        else
+
+        auto ItemActorClassProp = RowStruct->GetPropertyByName(TEXT("ItemActorClass"));
+        if (ItemActorClassProp && Type == TEXT("Armor"))
         {
-            bool LegalValue = true;
-            FMemory::Memcpy(LegalProp->ContainerPtrToValuePtr<void>(RowData.GetData()), &LegalValue, sizeof(bool));
+            FName ItemActorClassValue = ItemId;
+            FMemory::Memcpy(ItemActorClassProp->ContainerPtrToValuePtr<void>(RowData.GetData()), &ItemActorClassValue, sizeof(FName));
+        }
+
+        auto LegalProp = RowStruct->GetPropertyByName(TEXT("bLegalInGame"));
+        if (LegalProp)
+        {
+            if (Data.contains("bLegalInGame"))
+            {
+                PropertyHelper::CopyJsonValueToContainer(RowData.GetData(), LegalProp, Data.at("bLegalInGame"));
+            }
+            else
+            {
+                bool LegalValue = true;
+                FMemory::Memcpy(LegalProp->ContainerPtrToValuePtr<void>(RowData.GetData()), &LegalValue, sizeof(bool));
+            }
         }
 
         m_itemDataTable->AddRow(ItemId, *reinterpret_cast<RC::Unreal::FTableRowBase*>(RowData.GetData()));

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
  
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               6
-#define VERSION_REVISION            3
+#define VERSION_REVISION            4
 #define VERSION_BUILD               0
  
 #define VER_FILE_DESCRIPTION_STR    "PalSchema"


### PR DESCRIPTION
Turns out the value `ItemActorClass` in `DT_ItemDataTable` is used for the Antique Dresser to determine if an armor should work as a skin as discovered by the modder bombasticmori, so this is a similar case with the `SortID` in https://github.com/Okaetsu/PalSchema/pull/128.

This might fix any issues with glider skins as well, but I can't confirm.

Here's the widget blueprint handling what the Antique Dresser should display:
<img width="1510" height="393" alt="image" src="https://github.com/user-attachments/assets/5a1f16f7-6d57-4654-bec2-5421dfe400f5" />