### PR TITLE
Allow adding ranch suitability to new pals through pals json

### DIFF
--- a/src/Loader/PalMonsterModLoader.cpp
+++ b/src/Loader/PalMonsterModLoader.cpp
@@ -178,6 +178,7 @@ namespace Palworld {
 
         m_monsterDataTable->AddRow(CharacterId, *reinterpret_cast<RC::Unreal::FTableRowBase*>(MonsterRowData));
 
+        HandleRanchSuitability(static_cast<uint8_t*>(MonsterRowData), CharacterId, properties);
         AddTranslations(CharacterId, properties);
 
         PS::Log<RC::LogLevel::Normal>(STR("Added new Pal '{}'\n"), CharacterId.ToString());


### PR DESCRIPTION
Previously you could only add ranch suitability to pals through pals json if you were editing them. This was due to the assumption that modders would create custom spawn item actions through pak'd blueprints anyway, but I decided that new pals should have it too just for the sake of consistency.