### PR TITLE
Dll versioning cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ file(GLOB SRC_FILES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Misc/FileWatchWrapper.cpp"
 )
 
-add_library(${TARGET} SHARED ${SRC_FILES})
+add_library(${TARGET} SHARED ${SRC_FILES} version.rc)
 target_include_directories(${TARGET} PRIVATE 
     include/
 )

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
  
 #define VERSION_MAJOR               0
 #define VERSION_MINOR               6
-#define VERSION_REVISION            7
+#define VERSION_REVISION            71
 #define VERSION_BUILD               0
  
 #define VER_FILE_DESCRIPTION_STR    "PalSchema"


### PR DESCRIPTION
Originally I included version.rc so that PalSchema can display its version in the file metadata which is useful when viewing crashdumps for example. Turns out I forgot to include it in CMakeLists.txt, which was a requirement and as a result it would never display the version in the metadata.